### PR TITLE
support learning spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rspamd-iscan
 
-rspamd-iscan is a daemon that monitors IMAP mailboxes and forwards new mails to 
+rspamd-iscan is a daemon that monitors IMAP mailboxes and forwards new mails to
 [rspamd](https://rspamd.com) for spam analysis or ham classification.
 It is similar to [isbg](https://gitlab.com/isbg/isbg) but uses rspamd instead of
 Spamassassin.
@@ -8,12 +8,15 @@ Spamassassin.
 
 rspamd-iscan scans new mails arriving in a _ScanMailbox_, if they are classified
 as Spam they are moved to the _SpamMailbox_, otherwise to the _InboxMailbox_.
-The _ScanMailBox_ is monitor via IMAP IDLE for new E-Mails and additionally also
-scanned periodically. \
-All mails in _HamMailbox_ are fed as Ham to rspamd and then moved to
-_InboxMailbox_. The _HamMailbox_ is only processed periodically.
+The _ScanMailBox_ is monitored via IMAP IDLE for new E-Mails and additionally
+also scanned periodically. \
+Mails in _HamMailbox_ and _UndetectedMailbox_ are processed periodically and fed
+to rspamd to be learned as Ham/Spam.
+Mails that have been learned as Ham are moved to _InboxMailbox_, learned Spam
+mails are moved to _SpamMailbox_.
 
-The mails that have been scanned last are stored in a state file.
+The UID of the last scanned mail from _InboxMailbox_ is stored in a state file.
+This allows to use the same mailbox as _InboxMailbox_ and _ScanMailBox_.
 
 ## Configuration
 
@@ -21,16 +24,17 @@ rspamd-iscan can be configured via a TOML configuration file.
 Example:
 
 ```toml
-RspamdURL      = "http://192.168.178.2:11334"
-RspamdPassword = "iwonttellyou"
-ImapAddr       ="my-imap-server:993"
-ImapUser       ="rickdeckard"
-ImapPassword   ="zhora"
-InboxMailbox   ="INBOX"
-SpamMailbox    ="Spam"
-HamMailbox     = "Ham"
-ScanMailbox    ="Unscanned"
-SpamThreshold = 10.0
+RspamdURL           = "http://192.168.178.2:11334"
+RspamdPassword      = "iwonttellyou"
+ImapAddr            = "my-imap-server:993"
+ImapUser            = "rickdeckard"
+ImapPassword        = "zhora"
+InboxMailbox        = "INBOX"
+SpamMailbox         = "Spam"
+HamMailbox          = "Ham"
+UndetectedMailbox   = "Undetected"
+ScanMailbox         = "Unscanned"
+SpamThreshold       = 10.0
 ```
 
 The location of the configuration and state file can be specified via command

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ rspamd-iscan is a daemon that monitors IMAP mailboxes and forwards new mails to
 It is similar to [isbg](https://gitlab.com/isbg/isbg) but uses rspamd instead of
 Spamassassin.
 
-
 rspamd-iscan scans new mails arriving in a _ScanMailbox_, if they are classified
 as Spam they are moved to the _SpamMailbox_, otherwise to the _InboxMailbox_.
 The _ScanMailBox_ is monitored via IMAP IDLE for new E-Mails and additionally
@@ -39,3 +38,8 @@ SpamThreshold       = 10.0
 
 The location of the configuration and state file can be specified via command
 line parameters.
+
+## Project Status
+
+The application is work-in-progress, the documented functionality works and is
+in-use.

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -84,7 +84,7 @@ func NewClient(cfg *Config) (*Client, error) {
 		return nil, err
 	}
 
-	logger.Debug("connection established", "server", cfg.ServerAddr)
+	logger.Debug("connection established")
 
 	return c, nil
 }

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -218,7 +218,7 @@ func (c *Client) learn(srcMailbox, destMailbox string, learnFn learnFn) error {
 
 	logger.Debug("checking for new messages")
 
-	mbox, err := c.clt.Select(srcMailbox, &imap.SelectOptions{ReadOnly: true}).Wait()
+	mbox, err := c.clt.Select(srcMailbox, &imap.SelectOptions{}).Wait()
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func (c *Client) ProcessScanBox(startStatus *SeenStatus) (*SeenStatus, error) {
 
 	logger := c.logger.With("mailbox.source", c.scanMailbox)
 
-	mbox, err := c.clt.Select(c.scanMailbox, &imap.SelectOptions{ReadOnly: true}).Wait()
+	mbox, err := c.clt.Select(c.scanMailbox, &imap.SelectOptions{}).Wait()
 	if err != nil {
 		return startStatus, err
 	}

--- a/internal/rspamc/rspamc.go
+++ b/internal/rspamc/rspamc.go
@@ -12,6 +12,7 @@ import (
 type Client struct {
 	checkURL string
 	hamURL   string
+	spamURL  string
 	logger   *slog.Logger
 	password string
 }
@@ -20,6 +21,7 @@ func New(logger *slog.Logger, url, password string) *Client {
 	return &Client{
 		checkURL: url + "/checkv2",
 		hamURL:   url + "/learnham",
+		spamURL:  url + "/learnspam",
 		logger:   logger.WithGroup("rspamc").With("server", url),
 		password: password,
 	}
@@ -34,6 +36,7 @@ func (c *Client) sendRequest(ctx context.Context, url string, msg io.Reader, res
 
 	req.Header.Add("password", c.password)
 
+	// TODO: use custom client with configured timeouts
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil
@@ -68,6 +71,7 @@ func (c *Client) sendRequest(ctx context.Context, url string, msg io.Reader, res
 		if len(buf) != 0 {
 			logger.Warn("expected no response body but got one", "response", string(buf))
 		}
+
 		return nil
 	}
 
@@ -106,6 +110,10 @@ func (c *Client) Ham(ctx context.Context, msg io.Reader) error {
 	// }
 
 	return nil
+}
+
+func (c *Client) Spam(ctx context.Context, msg io.Reader) error {
+	return c.sendRequest(ctx, c.spamURL, msg, nil)
 }
 
 type learnHamReponse struct {

--- a/internal/rspamc/rspamc.go
+++ b/internal/rspamc/rspamc.go
@@ -83,8 +83,8 @@ func (c *Client) sendRequest(ctx context.Context, url string, msg io.Reader, res
 	return nil
 }
 
-func (c *Client) Check(ctx context.Context, msg io.Reader) (*Result, error) {
-	var result Result
+func (c *Client) Check(ctx context.Context, msg io.Reader) (*CheckResult, error) {
+	var result CheckResult
 	err := c.sendRequest(ctx, c.checkURL, msg, &result)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (c *Client) Spam(ctx context.Context, msg io.Reader) error {
 	return c.sendRequest(ctx, c.spamURL, msg, nil)
 }
 
-type Result struct {
+type CheckResult struct {
 	Action    string            `json:"action"`
 	Score     float32           `json:"score"`
 	IsSkipped bool              `json:"is_skipped"`

--- a/internal/rspamc/rspamc.go
+++ b/internal/rspamc/rspamc.go
@@ -93,31 +93,13 @@ func (c *Client) Check(ctx context.Context, msg io.Reader) (*Result, error) {
 }
 
 func (c *Client) Ham(ctx context.Context, msg io.Reader) error {
-	var resp learnHamReponse
-
-	err := c.sendRequest(ctx, c.hamURL, msg, &resp)
-	if err != nil {
-		return err
-	}
-
-	// resp code 208 == already learned, returns an json with an "error"
+	// resp code 208 == already learned, returns a json with an "error"
 	// field
-
-	// It is also unsuccessful if the same message has already learned
-	// before
-	// if !resp.Success {
-	// 	return errors.New("unsuccessful")
-	// }
-
-	return nil
+	return c.sendRequest(ctx, c.hamURL, msg, nil)
 }
 
 func (c *Client) Spam(ctx context.Context, msg io.Reader) error {
 	return c.sendRequest(ctx, c.spamURL, msg, nil)
-}
-
-type learnHamReponse struct {
-	Success bool `json:"success"`
 }
 
 type Result struct {

--- a/main.go
+++ b/main.go
@@ -19,16 +19,17 @@ var (
 )
 
 type Config struct {
-	RspamdURL      string
-	RspamdPassword string
-	ImapAddr       string
-	ImapUser       string
-	ImapPassword   string
-	InboxMailbox   string
-	SpamMailbox    string
-	ScanMailbox    string
-	HamMailbox     string
-	SpamThreshold  float32
+	RspamdURL         string
+	RspamdPassword    string
+	ImapAddr          string
+	ImapUser          string
+	ImapPassword      string
+	InboxMailbox      string
+	SpamMailbox       string
+	ScanMailbox       string
+	HamMailbox        string
+	UndetectedMailbox string
+	SpamThreshold     float32
 }
 
 func LoadConfig(path string) (*Config, error) {
@@ -84,17 +85,18 @@ func main() {
 
 	for {
 		clt, err := imap.NewClient(&imap.Config{
-			ServerAddr:      cfg.ImapAddr,
-			User:            cfg.ImapUser,
-			Passwd:          cfg.ImapPassword,
-			ScanMailbox:     cfg.ScanMailbox,
-			InboxMailbox:    cfg.InboxMailbox,
-			HamMailbox:      cfg.HamMailbox,
-			SpamMailboxName: cfg.SpamMailbox,
-			StateFilePath:   *stateFilePath,
-			SpamTreshold:    cfg.SpamThreshold,
-			Logger:          logger,
-			Rspamc:          rspamc,
+			ServerAddr:            cfg.ImapAddr,
+			User:                  cfg.ImapUser,
+			Passwd:                cfg.ImapPassword,
+			ScanMailbox:           cfg.ScanMailbox,
+			InboxMailbox:          cfg.InboxMailbox,
+			HamMailbox:            cfg.HamMailbox,
+			SpamMailboxName:       cfg.SpamMailbox,
+			UndetectedMailboxName: cfg.UndetectedMailbox,
+			StateFilePath:         *stateFilePath,
+			SpamTreshold:          cfg.SpamThreshold,
+			Logger:                logger,
+			Rspamc:                rspamc,
 		})
 		if err != nil {
 			logger.Error("creating imap client failed", "error", err)

--- a/main.go
+++ b/main.go
@@ -83,19 +83,19 @@ func main() {
 	rspamc := rspamc.New(logger, cfg.RspamdURL, cfg.RspamdPassword)
 
 	for {
-		clt, err := imap.NewClient(
-			cfg.ImapAddr,
-			cfg.ImapUser,
-			cfg.ImapPassword,
-			cfg.ScanMailbox,
-			cfg.InboxMailbox,
-			cfg.HamMailbox,
-			cfg.SpamMailbox,
-			*stateFilePath,
-			cfg.SpamThreshold,
-			logger,
-			rspamc,
-		)
+		clt, err := imap.NewClient(&imap.Config{
+			ServerAddr:      cfg.ImapAddr,
+			User:            cfg.ImapUser,
+			Passwd:          cfg.ImapPassword,
+			ScanMailbox:     cfg.ScanMailbox,
+			InboxMailbox:    cfg.InboxMailbox,
+			HamMailbox:      cfg.HamMailbox,
+			SpamMailboxName: cfg.SpamMailbox,
+			StateFilePath:   *stateFilePath,
+			SpamTreshold:    cfg.SpamThreshold,
+			Logger:          logger,
+			Rspamc:          rspamc,
+		})
 		if err != nil {
 			logger.Error("creating imap client failed", "error", err)
 			os.Exit(1)


### PR DESCRIPTION
This PR adds feeding emails that have been falsely not detected as spam to the rspamd `/learnspam` endpoint.
It works like like learning ham.

Mails in `UndetectedMailbox` are periodically processed and passed to rspamd as spam, afterwards they are moved to the `SpamMailbox`.

Fixes #2 