### PR TITLE
Add rspamd scan results to scanned mails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -1,4 +1,5 @@
 name: golangci-lint
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -16,5 +19,5 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-      - name: build
+      - name: test
         run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: build
+name: test
 
 on:
   push:
@@ -17,4 +17,4 @@ jobs:
         with:
           go-version: "1.24"
       - name: build
-        run: make build
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: build check
+all: build check test
 
 .PHONY: build
 build:
@@ -8,3 +8,7 @@ build:
 .PHONY: check
 check:
 	golangci-lint run ./...
+
+.PHONY: test
+test:
+	go test -race ./...

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ rspamd-iscan is a daemon that monitors IMAP mailboxes and forwards new mails to
 It is similar to [isbg](https://gitlab.com/isbg/isbg) but uses rspamd instead of
 Spamassassin.
 
-rspamd-iscan scans new mails arriving in a _ScanMailbox_, if they are classified
-as Spam they are moved to the _SpamMailbox_, otherwise to the _InboxMailbox_.
+rspamd-iscan scans new mails arriving in a _ScanMailbox_. The scan result is
+added as headers to the e-mail and the modified mail either uploaded to
+the _SpamMailbox_ or the _InboxMailbox_, depending on the classification.
+The unmodified original email is moved from the _ScanMailbox_ to the
+_BackupMailbox_.
 The _ScanMailBox_ is monitored via IMAP IDLE for new E-Mails and additionally
 also scanned periodically. \
 Mails in _HamMailbox_ and _UndetectedMailbox_ are processed periodically and fed
@@ -32,8 +35,12 @@ InboxMailbox        = "INBOX"
 SpamMailbox         = "Spam"
 HamMailbox          = "Ham"
 UndetectedMailbox   = "Undetected"
+BackupMailbox       = "Backup"
+TempDir             = "/tmp"
+KeepTempFiles       = true
 ScanMailbox         = "Unscanned"
 SpamThreshold       = 10.0
+
 ```
 
 The location of the configuration and state file can be specified via command

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fho/rspamd-scan
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/emersion/go-imap/v2 v2.0.0-beta.5

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+type Config struct {
+	RspamdURL         string
+	RspamdPassword    string
+	ImapAddr          string
+	ImapUser          string
+	ImapPassword      string
+	InboxMailbox      string
+	SpamMailbox       string
+	ScanMailbox       string
+	HamMailbox        string
+	BackupMailbox     string
+	UndetectedMailbox string
+	SpamThreshold     float32
+	TempDir           string
+	KeepTempFiles     bool
+}
+
+func (c *Config) String() string {
+	const unset = "UNSET"
+	const hiddenPasswd = "***"
+	var sb strings.Builder
+
+	printKv := func(k string, v any) {
+		fmt.Fprintf(&sb, "%-30v%-50v\n", k+":", v)
+	}
+
+	sb.WriteString("Configuration:\n")
+	printKv("Rspamd URL", c.RspamdURL)
+
+	if c.RspamdPassword == "" {
+		printKv("Rspamd Password", unset)
+	} else {
+		printKv("Rspamd Password", hiddenPasswd)
+	}
+
+	printKv("IMAP Server Address", c.ImapAddr)
+	printKv("IMAP User", c.ImapUser)
+
+	if c.ImapPassword == "" {
+		printKv("IMAP Password", unset)
+	} else {
+		printKv("IMAP Password", hiddenPasswd)
+	}
+
+	printKv("Spam Treshold", c.SpamThreshold)
+	printKv("Scan Mailbox", c.ScanMailbox)
+	printKv("Inbox Mailbox", c.InboxMailbox)
+	printKv("Spam Mailbox", c.SpamMailbox)
+	printKv("Undetected Mailbox", c.UndetectedMailbox)
+	printKv("Backup Mailbox", c.BackupMailbox)
+	printKv("Temporary Directory", c.TempDir)
+	printKv("Keep Temporary Files", c.KeepTempFiles)
+
+	sb.WriteRune('\n')
+	fmt.Fprintf(&sb, "Mails in %q are scanned and backuped to %q.\n", c.ScanMailbox, c.BackupMailbox)
+	fmt.Fprintf(&sb, "Mails with a spam score of >=%f are moved to %q,\n", c.SpamThreshold, c.SpamMailbox)
+	fmt.Fprintf(&sb, "others are moved to %q.\n", c.InboxMailbox)
+	if c.UndetectedMailbox != "" {
+		fmt.Fprintf(&sb, "Mails in %q are learned as Spam and moved to %q.\n", c.UndetectedMailbox, c.SpamMailbox)
+	}
+	fmt.Fprintf(&sb, "Mails in %q are learned as Ham and moved to %q.\n", c.HamMailbox, c.InboxMailbox)
+
+	return sb.String()
+}
+
+func FromFile(path string) (*Config, error) {
+	var result Config
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = toml.Unmarshal(buf, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (c *Config) SetDefaults() {
+	if c.TempDir == "" {
+		c.TempDir = os.TempDir()
+	}
+}
+
+func (c *Config) Validate() error {
+	if c.ScanMailbox == c.InboxMailbox {
+		return errors.New("ScanMailbox and InboxMailbox must differ")
+	}
+
+	if c.ScanMailbox == c.SpamMailbox {
+		return errors.New("ScanMailbox and SpamMailbox must differ")
+	}
+
+	if c.ScanMailbox == c.HamMailbox {
+		return errors.New("HamMailbox and SpamMailbox must differ")
+	}
+
+	if c.BackupMailbox == "" {
+		return errors.New("BackupMailbox can not be empty")
+	}
+
+	if c.BackupMailbox == c.InboxMailbox {
+		return errors.New("BackupMailbox and InboxMailbox must differ")
+	}
+
+	// Using the same mailbox for Spam, Ham and/or Backup would be weird but
+	// should work fine!
+	if c.SpamThreshold == 0 {
+		return errors.New("SpamThreshold must be >0")
+	}
+
+	fd, err := os.Stat(c.TempDir)
+	if err != nil {
+		return fmt.Errorf("invalid TempDir (%s): %w", c.TempDir, err)
+	}
+
+	if !fd.IsDir() {
+		return fmt.Errorf("specified TempDir (%s) is not a directory", c.TempDir)
+	}
+
+	return nil
+}

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -636,17 +636,17 @@ func (c *Client) Run() error {
 
 	err := c.ProcessHam()
 	if err != nil {
-		return fmt.Errorf("learning ham failed: %w", err)
+		return fmt.Errorf("learning ham failed: %w", WrapRetryableError(err))
 	}
 
 	err = c.ProcessSpam()
 	if err != nil {
-		return fmt.Errorf("learning spam failed: %w", err)
+		return fmt.Errorf("learning spam failed: %w", WrapRetryableError(err))
 	}
 
 	seen, err := c.ProcessScanBox(lastSeen)
 	if err != nil {
-		return err
+		return WrapRetryableError(err)
 	}
 	lastSeen = seen
 
@@ -673,17 +673,17 @@ func (c *Client) Run() error {
 
 			seen, err := c.ProcessScanBox(lastSeen)
 			if err != nil {
-				return err
+				return WrapRetryableError(err)
 			}
 			lastSeen = seen
 
 			if time.Since(lastLearn) >= c.learnInterval {
 				if err := c.ProcessHam(); err != nil {
-					return err
+					return WrapRetryableError(err)
 				}
 
 				if err := c.ProcessSpam(); err != nil {
-					return err
+					return WrapRetryableError(err)
 				}
 
 				lastLearn = time.Now()
@@ -707,7 +707,7 @@ func (c *Client) Run() error {
 
 			if time.Since(lastLearn) >= c.learnInterval {
 				if err := c.ProcessHam(); err != nil {
-					return err
+					return WrapRetryableError(err)
 				}
 				lastLearn = time.Now()
 			}
@@ -722,7 +722,7 @@ func (c *Client) Run() error {
 
 			seen, err := c.ProcessScanBox(lastSeen)
 			if err != nil {
-				return err
+				return WrapRetryableError(err)
 			}
 			lastSeen = seen
 

--- a/internal/imap/error.go
+++ b/internal/imap/error.go
@@ -34,7 +34,7 @@ func WrapRetryableError(err error) error {
 		if ne.Temporary() {
 			return &ErrRetryable{err: err}
 		}
-		slog.Debug("NOT A TEMPORARY ERR", "error", ne.Error())
+		slog.Debug("errRetryable: not a temporary error: ", "error", ne.Error())
 	}
 
 	return err

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -1,0 +1,168 @@
+package mail
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// maxLineLength is the max. allowed numbers of characters per line an e-mail,
+// *including* the terminating CRLF
+// (https://datatracker.ietf.org/doc/html/rfc2822#section-3.5)
+const maxLineLength = 1000
+
+// strEmailHdrCharsOnly removes all non-printable ASCII chars and colons from s
+func strEmailHdrCharsOnly(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= 33 && r <= 126 && r != ':' {
+			return r
+		}
+
+		return -1
+	}, s)
+}
+
+// AsHeader converts the header name and body to an email header line.
+// The line is terminated with \r\n.
+// If the header is invalid because it is too long or name or body contain
+// an invalid characters an error is returned.
+//
+// https://datatracker.ietf.org/doc/html/rfc2822#section-2.2
+func AsHeader(name, w string) ([]byte, error) {
+	nClean := strEmailHdrCharsOnly(name)
+	if len(nClean) != len(name) {
+		return nil, errors.New("header name contains an invalid character")
+	}
+
+	bClean := strEmailHdrCharsOnly(w)
+	if len(bClean) != len(w) {
+		return nil, errors.New("header body contains an invalid character")
+	}
+
+	hdr := append([]byte(nClean), ':', ' ')
+	hdr = append(hdr, []byte(bClean)...)
+	hdr = append(hdr, '\r', '\n')
+	if len(hdr) > maxLineLength {
+		return nil, errors.New("header is too long")
+	}
+
+	return hdr, nil
+}
+
+// AsHeaders converts the map to an email header section
+func AsHeaders(hdrs map[string]string) ([]byte, error) {
+	result := make([]byte, 0, 4096)
+
+	i := 0
+	for k, v := range hdrs {
+		hdr, err := AsHeader(k, v)
+		if err != nil {
+			return nil, fmt.Errorf("converting header '%q: %q' failed: %w", k, v, err)
+		}
+
+		result = append(result, hdr...)
+		i++
+	}
+
+	return slices.Clip(result), nil
+}
+
+// AddHeaders inserts additional headers to the e-mail at [path].
+// The file must be in RFC2822 format.
+func AddHeaders(path string, headers []byte) error {
+	tmpfileFd, err := os.CreateTemp("", filepath.Base(path))
+	if err != nil {
+		return err
+	}
+
+	emailFd, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer emailFd.Close()
+
+	err = addHeaders(emailFd, tmpfileFd, headers)
+	if err != nil {
+		_ = tmpfileFd.Close()
+		delErr := os.Remove(tmpfileFd.Name())
+		return errors.Join(err, delErr)
+	}
+
+	if err := tmpfileFd.Close(); err != nil {
+		delErr := os.Remove(tmpfileFd.Name())
+		return errors.Join(
+			fmt.Errorf("writing tempfile failed: %w", err),
+			delErr,
+		)
+	}
+
+	return os.Rename(tmpfileFd.Name(), path)
+}
+
+// addHeaders reads an email from in, inserts the additional headers and writes
+// the result to out.
+func addHeaders(in io.Reader, out io.Writer, hdrs []byte) error {
+	emailBr := bufio.NewReader(in)
+	tmpfileBw := bufio.NewWriter(out)
+
+	buf := make([]byte, 4096)
+
+	for {
+		n, err := emailBr.Read(buf)
+		if err != nil {
+			if err == io.EOF { //nolint:errorlint // errors.Is unnecessary here
+				return errors.New("header end not found")
+			}
+			return fmt.Errorf("reading email failed: %w", err)
+		}
+
+		idx := bytes.Index(buf[:n], []byte("\r\n\r\n"))
+		if idx != -1 {
+			// header end found, copy up to the delim
+			_, err = tmpfileBw.Write(buf[:idx])
+			if err != nil {
+				return fmt.Errorf("copying data failed: %w", err)
+			}
+
+			// +2 to skip the \r\n of the last header line, all
+			// lines in hdrs are already expected to be \r\n
+			// terminated
+			buf = buf[idx+2 : n]
+			break
+		}
+
+		_, err = tmpfileBw.Write(buf[:n])
+		if err != nil {
+			return fmt.Errorf("copying data failed: %w", err)
+		}
+	}
+
+	if _, err := tmpfileBw.Write([]byte("\r\n")); err != nil {
+		return fmt.Errorf("writing failed: %w", err)
+	}
+
+	if _, err := tmpfileBw.Write(hdrs); err != nil {
+		return fmt.Errorf("writing failed: %w", err)
+	}
+
+	// write remaining data from already read buffer
+	if _, err := tmpfileBw.Write(buf); err != nil {
+		return fmt.Errorf("writing failed: %w", err)
+	}
+
+	if _, err := io.Copy(tmpfileBw, emailBr); err != nil {
+		return fmt.Errorf("copying email failed: %w", err)
+	}
+
+	if err := tmpfileBw.Flush(); err != nil {
+		return fmt.Errorf("flushing buffer failed: %w", err)
+	}
+
+	return nil
+}

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -1,0 +1,56 @@
+package mail
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func AssertNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func AssertErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAddHeaders(t *testing.T) {
+	const expected = "From: someone@example.com\r\nTo: someone_else@example.com\r\nSubject: An RFC 822 formatted message\r\nNew-Header1: v1\r\nNew-Header2: v2\r\n\r\nThis is the plain text body of the message. Note the blank line\r\nbetween the header information and the body of the message.\r\n"
+
+	tmpdir := t.TempDir()
+	fd, err := os.CreateTemp(tmpdir, t.Name())
+	AssertNoErr(t, err)
+
+	exampleFd, err := os.Open(filepath.Join("testdata", "example.mail"))
+	AssertNoErr(t, err)
+
+	_, err = io.Copy(fd, exampleFd)
+	AssertNoErr(t, err)
+
+	err = fd.Close()
+	AssertNoErr(t, err)
+	_ = exampleFd.Close()
+
+	hdrs, err := AsHeaders(map[string]string{
+		"New-Header1": "v1",
+		"New-Header2": "v2",
+	})
+	AssertNoErr(t, err)
+	err = AddHeaders(fd.Name(), hdrs)
+	AssertNoErr(t, err)
+
+	result, err := os.ReadFile(fd.Name())
+	AssertNoErr(t, err)
+
+	if !bytes.Equal(result, []byte(expected)) {
+		t.Errorf("Got:\n%q\nExpected:\n%q\n", string(result), expected)
+	}
+}

--- a/internal/mail/testdata/example.mail
+++ b/internal/mail/testdata/example.mail
@@ -1,0 +1,6 @@
+From: someone@example.com
+To: someone_else@example.com
+Subject: An RFC 822 formatted message
+
+This is the plain text body of the message. Note the blank line
+between the header information and the body of the message.

--- a/internal/rspamc/rspamc.go
+++ b/internal/rspamc/rspamc.go
@@ -83,7 +83,9 @@ func (c *Client) sendRequest(ctx context.Context, url string, msg io.Reader, res
 
 func (c *Client) Check(ctx context.Context, msg io.Reader) (*CheckResult, error) {
 	var result CheckResult
-	err := c.sendRequest(ctx, c.checkURL, msg, &result)
+	// wrap in NopCloser to prevent that http.NewRequest closes the reader,
+	// it is not responsible for closing it, the caller is
+	err := c.sendRequest(ctx, c.checkURL, io.NopCloser(msg), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -101,10 +103,10 @@ func (c *Client) Spam(ctx context.Context, msg io.Reader) error {
 }
 
 type CheckResult struct {
-	Action    string            `json:"action"`
-	Score     float32           `json:"score"`
-	IsSkipped bool              `json:"is_skipped"`
-	Symbols   map[string]Symbol `json:"symbols"`
+	Action    string             `json:"action"`
+	Score     float32            `json:"score"`
+	IsSkipped bool               `json:"is_skipped"`
+	Symbols   map[string]*Symbol `json:"symbols"`
 }
 
 // https://rspamd.com/doc/architecture/protocol.html#protocol-basics

--- a/main.go
+++ b/main.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 
+	"github.com/fho/rspamd-scan/internal/config"
 	"github.com/fho/rspamd-scan/internal/imap"
 	"github.com/fho/rspamd-scan/internal/rspamc"
 
-	"github.com/pelletier/go-toml/v2"
 	flag "github.com/spf13/pflag"
 )
 
@@ -18,132 +17,6 @@ var (
 	version = "version-undefined"
 	commit  = "commit-undefined"
 )
-
-// TODO: move Config to own file or package
-type Config struct {
-	RspamdURL         string
-	RspamdPassword    string
-	ImapAddr          string
-	ImapUser          string
-	ImapPassword      string
-	InboxMailbox      string
-	SpamMailbox       string
-	ScanMailbox       string
-	HamMailbox        string
-	BackupMailbox     string
-	UndetectedMailbox string
-	SpamThreshold     float32
-	TempDir           string
-	KeepTempFiles     bool
-}
-
-func (c *Config) String() string {
-	const unset = "UNSET"
-	const hiddenPasswd = "***"
-	var sb strings.Builder
-
-	printKv := func(k string, v any) {
-		fmt.Fprintf(&sb, "%-30v%-50v\n", k+":", v)
-	}
-
-	sb.WriteString("Configuration:\n")
-	printKv("Rspamd URL", c.RspamdURL)
-
-	if c.RspamdPassword == "" {
-		printKv("Rspamd Password", unset)
-	} else {
-		printKv("Rspamd Password", hiddenPasswd)
-	}
-
-	printKv("IMAP Server Address", c.ImapAddr)
-	printKv("IMAP User", c.ImapUser)
-
-	if c.ImapPassword == "" {
-		printKv("IMAP Password", unset)
-	} else {
-		printKv("IMAP Password", hiddenPasswd)
-	}
-
-	printKv("Spam Treshold", c.SpamThreshold)
-	printKv("Scan Mailbox", c.ScanMailbox)
-	printKv("Inbox Mailbox", c.InboxMailbox)
-	printKv("Spam Mailbox", c.SpamMailbox)
-	printKv("Undetected Mailbox", c.UndetectedMailbox)
-	printKv("Backup Mailbox", c.BackupMailbox)
-	printKv("Temporary Directory", c.TempDir)
-	printKv("Keep Temporary Files", c.KeepTempFiles)
-
-	sb.WriteRune('\n')
-	fmt.Fprintf(&sb, "Mails in %q are scanned and backuped to %q.\n", c.ScanMailbox, c.BackupMailbox)
-	fmt.Fprintf(&sb, "Mails with a spam score of >=%f are moved to %q,\n", c.SpamThreshold, c.SpamMailbox)
-	fmt.Fprintf(&sb, "others are moved to %q.\n", c.InboxMailbox)
-	if c.UndetectedMailbox != "" {
-		fmt.Fprintf(&sb, "Mails in %q are learned as Spam and moved to %q.\n", c.UndetectedMailbox, c.SpamMailbox)
-	}
-	fmt.Fprintf(&sb, "Mails in %q are learned as Ham and moved to %q.\n", c.HamMailbox, c.InboxMailbox)
-
-	return sb.String()
-}
-
-func LoadConfig(path string) (*Config, error) {
-	var result Config
-	buf, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	err = toml.Unmarshal(buf, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result, nil
-}
-
-func (c *Config) SetDefaults() {
-	if c.TempDir == "" {
-		c.TempDir = os.TempDir()
-	}
-}
-
-func (c *Config) Validate() error {
-	if c.ScanMailbox == c.InboxMailbox {
-		return errors.New("ScanMailbox and InboxMailbox must differ")
-	}
-
-	if c.ScanMailbox == c.SpamMailbox {
-		return errors.New("ScanMailbox and SpamMailbox must differ")
-	}
-
-	if c.ScanMailbox == c.HamMailbox {
-		return errors.New("HamMailbox and SpamMailbox must differ")
-	}
-
-	if c.BackupMailbox == "" {
-		return errors.New("BackupMailbox can not be empty")
-	}
-
-	if c.BackupMailbox == c.InboxMailbox {
-		return errors.New("BackupMailbox and InboxMailbox must differ")
-	}
-
-	// Using the same mailbox for Spam, Ham and/or Backup would be weird but
-	// should work fine!
-
-	if c.SpamThreshold == 0 {
-		return errors.New("SpamThreshold must be >0")
-	}
-
-	fd, err := os.Stat(c.TempDir)
-	if err != nil {
-		return fmt.Errorf("invalid TempDir (%s): %w", c.TempDir, err)
-	}
-
-	if !fd.IsDir() {
-		return fmt.Errorf("specified TempDir (%s) is not a directory", c.TempDir)
-	}
-
-	return nil
-}
 
 func main() {
 	cfgPath := flag.String("cfg-file", "rspamd-iscan.toml", "Path to the rspamd-iscan config file")
@@ -169,7 +42,7 @@ func main() {
 	})
 	logger := slog.New(h)
 
-	cfg, err := LoadConfig(*cfgPath)
+	cfg, err := config.FromFile(*cfgPath)
 	if err != nil {
 		logger.Error("loading config failed", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
The rspamd scan symbols with their value are now added to scanned
emails.
Emails in the ScanMailbox are now downloaded and stored in the directory
that can be configured via the TempDir directive in the configuration
file.
Afterwards they are passed to rspamd for scanning.
Rspamd returns the total score and the invididual score symbols.
A local copy of the downloaded email is created, where the symbols are
added as additional e-mail headers, prefixed with "X-rspamd-iscan-".
All symbols with a 0 score are omitted.
The original email is then moved to a backup mailbox, that can be
configured via the new BackupMailbox directive in the config file.
Afterwards the modified e-mail is uploaded to the INBOX mailbox.

The backup mailbox exist, to prevent that e-mails are lost because of
bugs this new feature. A configuration option can be added later to
disable backing up the original e-mails.
Currently the user has to delete old emails from the backup mailbox
manually.

Also:
- mailboxes are not opened read-only anymore when messages are moved
  afterwards, when fetching messages of those the Peek flag is now set
  correctly to prevent that their status changed to read
- The stateFile is removed. This means that the ScanMailbox and
  InboxMailbox can't be the same mailbox anymore.
- When errors happening while scanning e-mails, the erroneous ones are skipped and scanning continues.
  The operations returns all collected errors at the end.
  Previously the scan operation aborted as soon as an error happened,
  not continuing to scan other available emails.

See commit messages for more details.

Fixes #3 