### PR TITLE
pass smtp envelope information to rspamc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fho/rspamd-iscan
 
-go 1.24.4
+go 1.24.5
 
 require (
 	github.com/emersion/go-imap/v2 v2.0.0-beta.5

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emersion/go-imap/v2 v2.0.0-beta.3 h1:z0TLMfYnDsFupXLhzRXgOzXenD3uPvNniQSu5fN1teg=
-github.com/emersion/go-imap/v2 v2.0.0-beta.3/go.mod h1:BZTFHsS1hmgBkFlHqbxGLXk2hnRqTItUgwjSSCsYNAk=
 github.com/emersion/go-imap/v2 v2.0.0-beta.5 h1:H3858DNmBuXyMK1++YrQIRdpKE1MwBc+ywBtg3n+0wA=
 github.com/emersion/go-imap/v2 v2.0.0-beta.5/go.mod h1:BZTFHsS1hmgBkFlHqbxGLXk2hnRqTItUgwjSSCsYNAk=
 github.com/emersion/go-message v0.18.1 h1:tfTxIoXFSFRwWaZsgnqS1DSZuGpYGzSmCZD8SK3QA2E=

--- a/internal/rspamc/mailheaders.go
+++ b/internal/rspamc/mailheaders.go
@@ -1,0 +1,36 @@
+package rspamc
+
+import (
+	"net/http"
+)
+
+// MailHeaders contains optional pre-processed email data, to prevent redundant
+// processing of mail headers in rspamd
+type MailHeaders struct {
+	DeliverTo  string
+	From       []string
+	Recipients []string
+	Subject    string
+}
+
+func (h *MailHeaders) asHeader() http.Header {
+	result := http.Header{}
+
+	if h.DeliverTo != "" {
+		result.Add("Deliver-To", h.DeliverTo)
+	}
+
+	if h.Subject != "" {
+		result.Add("Subject", h.Subject)
+	}
+
+	for _, rcpt := range h.Recipients {
+		result.Add("Rcpt", rcpt)
+	}
+
+	for _, rcpt := range h.From {
+		result.Add("From", rcpt)
+	}
+
+	return result
+}


### PR DESCRIPTION
To minimize redundant processing of mail data, pass the SMTP envelope information feteched from the IMAP server to rspamc when checking and learning messages

Fixes: #7 