### PR TITLE
terminate gracefully on SIGTERM, SIGINT

### DIFF
--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -51,8 +51,11 @@ type Client struct {
 
 	rspamc RspamdClient
 
-	// cntScannedMails is only used in testcases
-	cntScannedMails atomic.Uint64
+	// cntProcessedMails counts the number of emails that have been processed
+	// in the [Client.scanMailbox], [Client.hamMailbox] and [Client.
+	// spamMailbox].
+	// It is only used in tests.
+	cntProcessedMails atomic.Uint64
 }
 
 type scannedMail struct {
@@ -157,6 +160,8 @@ func (c *Client) learn(srcMailbox, destMailbox string, learnFn learnFn) error {
 	if err != nil {
 		return fmt.Errorf("moving messages after learning failed: %w", err)
 	}
+
+	c.cntProcessedMails.Add(uint64(len(learnedMsgUIDs)))
 
 	return nil
 }
@@ -378,7 +383,7 @@ func (c *Client) ProcessScanBox() error {
 		errs = append(errs, err)
 	}
 
-	c.cntScannedMails.Add(1)
+	c.cntProcessedMails.Add(uint64(len(scannedMails)))
 
 	return errors.Join(errs...)
 }

--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -412,7 +412,6 @@ func (c *Client) Start() error {
 	}
 
 	for {
-
 		eventCh, monitorCancelFn, err := c.clt.Monitor(c.scanMailbox)
 		if err != nil {
 			return WrapRetryableError(err)

--- a/internal/iscan/client_test.go
+++ b/internal/iscan/client_test.go
@@ -111,7 +111,7 @@ func TestRun(t *testing.T) {
 	err = clt2.clt.Upload(mail.TestSpamMailPath(t), srv.UndetectedMailbox, time.Now())
 	assert.NoError(t, err)
 
-	for clt.cntScannedMails.Load() < 4 {
+	for clt.cntProcessedMails.Load() < 4 {
 		time.Sleep(50 * time.Millisecond)
 	}
 

--- a/internal/log/testlogger.go
+++ b/internal/log/testlogger.go
@@ -10,8 +10,7 @@ import (
 func SlogTestLogger(t *testing.T) *slog.Logger {
 	return slog.New(
 		slog.NewTextHandler(t.Output(), &slog.HandlerOptions{
-			AddSource: true,
-			Level:     slog.LevelDebug,
+			Level: slog.LevelDebug,
 		}),
 	)
 }


### PR DESCRIPTION
When SIGTERM or SIGINTER is received, call iscan.Stop() to terminate gracefully. This prevents that messages are processed only partially, resulting in e.g. a learned messages, with a copy in the backup mailbox and the original message still in the Unscanned mailbox.