### PR TITLE
sort X-rspamd-iscan- headers

### DIFF
--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -40,9 +40,9 @@ func TestAddHeaders(t *testing.T) {
 	AssertNoErr(t, err)
 	_ = exampleFd.Close()
 
-	hdrs, err := AsHeaders(map[string]string{
-		"New-Header1": "v1",
-		"New-Header2": "v2",
+	hdrs, err := AsHeaders([]*Header{
+		{Name: "New-Header1", Body: "v1"},
+		{Name: "New-Header2", Body: "v2"},
 	})
 	AssertNoErr(t, err)
 	err = AddHeaders(fd.Name(), hdrs)


### PR DESCRIPTION
To make it easier to read the X-rspamd-iscan- headers that are added to mails, sort them and order the X-rspamd-iscan-Score Header always as last.
The X-rspamd-iscan-Score is most interesting and therefore given a fixed, easy to find, position.