### PR TITLE
add --once and --dry-run command line flags

### DIFF
--- a/internal/imapclt/dry_client.go
+++ b/internal/imapclt/dry_client.go
@@ -1,0 +1,31 @@
+package imapclt
+
+import "time"
+
+// DryClient is an IMAP client that simulates operations that do changes on the
+// IMAP-Server.
+type DryClient struct {
+	*Client
+}
+
+// NewDryClient creates an new IMAP-Client.
+// [*DryClient.Connect] must be called before any other methods.
+func NewDryClient(cfg *Config) *DryClient {
+	return &DryClient{Client: NewClient(cfg)}
+}
+
+// Upload logs a debug message and returns nil
+func (c *DryClient) Upload(path, mailbox string, _ time.Time) error {
+	c.logger.Debug("dry-client: skipping uploading mail to mailbox",
+		lkMailbox, mailbox, "filepath", path)
+	return nil
+}
+
+// Move logs a debug message and returns nil
+func (c *DryClient) Move(uids []uint32, mailbox string) error {
+	c.logger.Debug("dry-client: skipping moving messages to mailbox",
+		lkMailbox, mailbox,
+		"count", len(uids),
+	)
+	return nil
+}

--- a/internal/imapclt/imap_utils_test.go
+++ b/internal/imapclt/imap_utils_test.go
@@ -32,12 +32,14 @@ func startServerClient(t *testing.T) (*imapserver.Server, *Client) {
 
 func newTestClient(t *testing.T, srv *imapserver.Server) *Client {
 	var err error
-	var clt *Client
+
+	clt := NewClient(testClientCfg(t, srv))
 
 	// we retry connecting because the server might not have finished
 	// startup
+
 	for range 9 {
-		clt, err = Connect(testClientCfg(t, srv))
+		err = clt.Connect()
 		if err != nil {
 			t.Logf("establishing connection to imap server failed (server still starting?): %s", err)
 			time.Sleep(500 * time.Millisecond)

--- a/internal/iscan/client_test.go
+++ b/internal/iscan/client_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fho/rspamd-iscan/internal/imapclt"
 	"github.com/fho/rspamd-iscan/internal/log"
 	"github.com/fho/rspamd-iscan/internal/rspamc"
 	"github.com/fho/rspamd-iscan/internal/testutils/assert"
@@ -139,7 +138,7 @@ func TestRun(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func mailboxIsEmpty(t *testing.T, clt *imapclt.Client, mailbox string) bool {
+func mailboxIsEmpty(t *testing.T, clt IMAPClient, mailbox string) bool {
 	for _, err := range clt.Messages(mailbox) {
 		assert.NoError(t, err)
 		return false
@@ -149,7 +148,7 @@ func mailboxIsEmpty(t *testing.T, clt *imapclt.Client, mailbox string) bool {
 
 func mailboxContainsMailCnt(
 	t *testing.T,
-	clt *imapclt.Client,
+	clt IMAPClient,
 	mailbox string,
 	mailSubject string,
 ) int {


### PR DESCRIPTION
```
add --dry-run command line flag

When --dry-run is passed, a special IMAP client is used that only
pretends to Move and Upload E-Mails.

This can be used for testing the rspamd-iscan functionality, without the
risk of altering IMAP mailboxes.

--dry-run also enables --once, this is required to prevent that in
monitoring mode the same messages will be processed over and over again.
--dry-run could be supported in monitoring mode if the already processed
messages would be tracked. It's not worth to add the functionality only
for the dry-run mode though.

-------------------------------------------------------------------------------
fix: close is called for former iscan.Clients instances on retry

When a retryable error occurs in main(), the signal handler that calls
close on iscan.Client is kept installed.

This means the iscan.Client instances must also be kept in memory. This
is a memory leak.

It is fixed by refactoring main() and removing all installed signal
handlers when a client returns an error, before a new one is created.

It would be good to split creating a Client and establishing the
connection into 2 methods in a follow-up, to prevent recreating the
iscan.Client unnecessarily on every retry.

-------------------------------------------------------------------------------
add --once command line flag

When --once is passed to rspamd-client, all found mails in the ham, spam
and scan mailbox are processed once and then it terminates.

This is a prerequisite for implementing a --dry-run flag in a follow-up.

-------------------------------------------------------------------------------
```

Closes #11 