### PR TITLE
Add support for reading password from a different file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ ScanMailbox         = "Unscanned"
 SpamThreshold       = 10.0
 ```
 
+### Credentials Directory
+
+Instead of storing sensitive credentials directly in the config file, you can use
+the `--credentials-directory` flag to specify a directory containing credential files.
+This is compatible with [systemd credentials](https://systemd.io/CREDENTIALS/).
+
+If the credentials directory is set, rspamd-iscan looks for files named after the
+config fields: `RspamdURL`, `RspamdPassword`, `ImapUser`, `ImapPassword`. If a file
+exists, its content overwrites the corresponding value from the TOML config.
+
+The `--credentials-directory` flag defaults to the `CREDENTIALS_DIRECTORY` environment
+variable if not specified.
+
+Example directory structure:
+```
+/run/credentials/rspamd-iscan/
+├── RspamdPassword
+├── ImapUser
+└── ImapPassword
+```
+
 ## Running
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
@@ -91,4 +92,52 @@ func (c *Config) SetDefaults() {
 	if c.TempDir == "" {
 		c.TempDir = os.TempDir()
 	}
+}
+
+// LoadCredentialsFromDirectory reads credentials from files in the specified directory.
+// If a file exists, its content overwrites the corresponding config value.
+func (c *Config) LoadCredentialsFromDirectory(dir string) error {
+	if _, err := os.Stat(dir); err != nil {
+		return fmt.Errorf("credentials directory: %w", err)
+	}
+
+	credentials := []struct {
+		name   string
+		target *string
+	}{
+		{"RspamdURL", &c.RspamdURL},
+		{"RspamdPassword", &c.RspamdPassword},
+		{"ImapUser", &c.ImapUser},
+		{"ImapPassword", &c.ImapPassword},
+	}
+
+	for _, cred := range credentials {
+		path := filepath.Join(dir, cred.name)
+		value, err := readCredentialFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("reading credential %s: %w", cred.name, err)
+		}
+		*cred.target = value
+	}
+
+	return nil
+}
+
+func readCredentialFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	// Trim trailing newlines because editors often add
+	// an empty newline at the end of the file
+	value := strings.TrimRight(string(data), "\r\n")
+
+	if value == "" {
+		return "", fmt.Errorf("file is empty")
+	}
+	return value, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,8 +94,9 @@ func (c *Config) SetDefaults() {
 	}
 }
 
-// LoadCredentialsFromDirectory reads credentials from files in the specified directory.
-// If a file exists, its content overwrites the corresponding config value.
+// LoadCredentialsFromDirectory reads credentials from files in the specified
+// directory. If a file exists, its content overwrite the corresponding config
+// value.
 func (c *Config) LoadCredentialsFromDirectory(dir string) error {
 	if _, err := os.Stat(dir); err != nil {
 		return fmt.Errorf("credentials directory: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fho/rspamd-iscan/internal/testutils/assert"
+)
+
+func TestLoadCredentialsFromDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte("secret123"), 0600)
+	_ = os.WriteFile(filepath.Join(dir, "ImapUser"), []byte("testuser"), 0600)
+
+	cfg := &Config{
+		RspamdURL:      "http://original.url",
+		RspamdPassword: "original",
+	}
+
+	err := cfg.LoadCredentialsFromDirectory(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, "secret123", cfg.RspamdPassword)
+	assert.Equal(t, "testuser", cfg.ImapUser)
+	assert.Equal(t, "http://original.url", cfg.RspamdURL)
+}
+
+func TestLoadCredentialsFromDirectory_MissingFilesSkipped(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte("secret"), 0600)
+
+	cfg := &Config{ImapPassword: "original"}
+
+	err := cfg.LoadCredentialsFromDirectory(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, "secret", cfg.RspamdPassword)
+	assert.Equal(t, "original", cfg.ImapPassword)
+}
+
+func TestLoadCredentialsFromDirectory_DirNotExistsError(t *testing.T) {
+	cfg := &Config{}
+	err := cfg.LoadCredentialsFromDirectory("/nonexistent/path")
+	assert.Error(t, err)
+	assert.Equal(t, "credentials directory: stat /nonexistent/path: no such file or directory", err.Error())
+}
+
+func TestLoadCredentialsFromDirectory_EmptyFileError(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte(""), 0600)
+
+	cfg := &Config{}
+	err := cfg.LoadCredentialsFromDirectory(dir)
+	assert.Error(t, err)
+	assert.Equal(t, "reading credential RspamdPassword: file is empty", err.Error())
+}
+
+func TestLoadCredentialsFromDirectory_PreservesSpaces(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte(" spaces \nnewline\n"), 0600)
+	_ = os.WriteFile(filepath.Join(dir, "ImapPassword"), []byte(" spaces \r\nnewline\n\r"), 0600)
+
+	cfg := &Config{}
+	err := cfg.LoadCredentialsFromDirectory(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, " spaces \nnewline", cfg.RspamdPassword)
+	assert.Equal(t, " spaces \r\nnewline", cfg.ImapPassword)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestLoadCredentialsFromDirectory(t *testing.T) {
 	dir := t.TempDir()
-	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte("secret123"), 0600)
-	_ = os.WriteFile(filepath.Join(dir, "ImapUser"), []byte("testuser"), 0600)
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte("secret123"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "ImapUser"), []byte("testuser"), 0o600)
 
 	cfg := &Config{
 		RspamdURL:      "http://original.url",
@@ -27,7 +27,7 @@ func TestLoadCredentialsFromDirectory(t *testing.T) {
 
 func TestLoadCredentialsFromDirectory_MissingFilesSkipped(t *testing.T) {
 	dir := t.TempDir()
-	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte("secret"), 0600)
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte("secret"), 0o600)
 
 	cfg := &Config{ImapPassword: "original"}
 
@@ -46,7 +46,7 @@ func TestLoadCredentialsFromDirectory_DirNotExistsError(t *testing.T) {
 
 func TestLoadCredentialsFromDirectory_EmptyFileError(t *testing.T) {
 	dir := t.TempDir()
-	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte(""), 0600)
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte(""), 0o600)
 
 	cfg := &Config{}
 	err := cfg.LoadCredentialsFromDirectory(dir)
@@ -56,8 +56,8 @@ func TestLoadCredentialsFromDirectory_EmptyFileError(t *testing.T) {
 
 func TestLoadCredentialsFromDirectory_PreservesSpaces(t *testing.T) {
 	dir := t.TempDir()
-	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte(" spaces \nnewline\n"), 0600)
-	_ = os.WriteFile(filepath.Join(dir, "ImapPassword"), []byte(" spaces \r\nnewline\n\r"), 0600)
+	_ = os.WriteFile(filepath.Join(dir, "RspamdPassword"), []byte(" spaces \nnewline\n"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "ImapPassword"), []byte(" spaces \r\nnewline\n\r"), 0o600)
 
 	cfg := &Config{}
 	err := cfg.LoadCredentialsFromDirectory(dir)

--- a/main.go
+++ b/main.go
@@ -21,10 +21,11 @@ var (
 )
 
 type flags struct {
-	cfgPath      string
-	printVersion bool
-	once         bool
-	dryRun       bool
+	cfgPath              string
+	credentialsDirectory string
+	printVersion         bool
+	once                 bool
+	dryRun               bool
 }
 
 func mustParseFlags() *flags {
@@ -32,6 +33,8 @@ func mustParseFlags() *flags {
 
 	flag.StringVar(&result.cfgPath, "cfg-file", "/etc/rspamd-iscan/config.toml",
 		"Path to the rspamd-iscan config file")
+	flag.StringVar(&result.credentialsDirectory, "credentials-directory", os.Getenv("CREDENTIALS_DIRECTORY"),
+		"Directory containing credential files (defaults to $CREDENTIALS_DIRECTORY)")
 	flag.BoolVar(&result.printVersion, "version", false,
 		"print the version and exit")
 	flag.BoolVar(&result.once, "once", false,
@@ -204,6 +207,13 @@ func main() {
 	if err != nil {
 		logger.Error("loading config failed", "error", err)
 		os.Exit(1)
+	}
+
+	if flags.credentialsDirectory != "" {
+		if err := cfg.LoadCredentialsFromDirectory(flags.credentialsDirectory); err != nil {
+			logger.Error("loading credentials from directory failed", "error", err)
+			os.Exit(1)
+		}
 	}
 
 	cfg.SetDefaults()


### PR DESCRIPTION
Hey fho, I hope you are open for pull requests 😁

I started to use rspamd-iscan, but I am handling my secret separately from my config file. So I make this little patch that allows rspamd-iscan to read the password for RspamdPasswordFile and ImapPasswordFile from a separate file.
I hope that you will accept it.