### PR TITLE
fix: retry monitoring on closed network connection again

### DIFF
--- a/internal/neterr/error.go
+++ b/internal/neterr/error.go
@@ -3,6 +3,7 @@ package neterr
 import (
 	"errors"
 	"io"
+	"net"
 	"syscall"
 )
 
@@ -15,7 +16,8 @@ func IsRetryableError(err error) bool {
 		errors.Is(err, syscall.ETIMEDOUT),
 		errors.Is(err, syscall.ENETUNREACH),
 		errors.Is(err, syscall.EHOSTUNREACH),
-		errors.Is(err, io.ErrUnexpectedEOF):
+		errors.Is(err, io.ErrUnexpectedEOF),
+		errors.Is(err, net.ErrClosed):
 		return true
 	default:
 		return false

--- a/internal/neterr/error_test.go
+++ b/internal/neterr/error_test.go
@@ -13,3 +13,19 @@ func TestIsRetryableError_ConnectionRefused(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, true, IsRetryableError(err))
 }
+
+func TestIsRetryableError_ClosedConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	assert.NoError(t, err)
+	defer ln.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	assert.NoError(t, err)
+
+	conn.Close()
+
+	_, err = conn.Write([]byte("test"))
+	t.Logf("error: %v", err)
+	assert.Error(t, err)
+	assert.Equal(t, true, IsRetryableError(err))
+}


### PR DESCRIPTION
73a9302 introduced the issue that rspamd-iscan is not restarting the monitor loop anymore when a connection was closed.

Retry when a net.ErrClosed happens.