### PR TITLE
feat: implement subject rewriting

### DIFF
--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -227,15 +227,29 @@ func (c *Client) isSpam(r *rspamc.CheckResult) bool {
 	return r.Score >= c.spamTreshold
 }
 
-func handleSubjectRewrite(env *imapclt.Envelope, scanResult *rspamc.CheckResult, logger *slog.Logger) {
-	if scanResult.Subject != "" && scanResult.Subject != env.Subject {
-		old := env.Subject
-		env.Subject = scanResult.Subject
-		logger.Debug("rspamd returned modified subject",
-			"old_subject", old,
-			"new_subject", env.Subject,
-		)
+func rewriteSubject(mailFilepath string, env *imapclt.Envelope, result *rspamc.CheckResult, logger *slog.Logger) error {
+	if result.Subject == "" || result.Subject == env.Subject {
+		return nil
 	}
+
+	old := env.Subject
+	env.Subject = result.Subject
+
+	hdr := mail.Header{
+		Name: "Subject",
+		Body: result.Subject,
+	}
+
+	if err := mail.ReplaceHeader(mailFilepath, hdr); err != nil {
+		return fmt.Errorf("replacing subject header failed: %w", err)
+	}
+
+	logger.Debug("rspamd returned modified subject",
+		"old_subject", old,
+		"new_subject", env.Subject,
+	)
+
+	return nil
 }
 
 // replaceWithModifiedMails uploads mails to the spam or inbox mailbox, depending on their
@@ -364,7 +378,10 @@ func (c *Client) downloadAndScan(msg *imapclt.Message) (*scannedMail, error) {
 		return nil, fmt.Errorf("closing file of downloaded mail failed: %w", err)
 	}
 
-	handleSubjectRewrite(env, scanResult, logger)
+	err = rewriteSubject(tmpFile.Name(), env, scanResult, logger)
+	if err != nil {
+		return nil, err
+	}
 
 	err = addScanResultHeaders(tmpFile.Name(), scanResult)
 	if err != nil {

--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -236,31 +236,6 @@ func (c *Client) isSpam(r *rspamc.CheckResult) bool {
 	return r.Score >= c.spamTreshold
 }
 
-func rewriteSubject(mailFilepath string, env *imapclt.Envelope, result *rspamc.CheckResult, logger *slog.Logger) error {
-	if result.Subject == "" || result.Subject == env.Subject {
-		return nil
-	}
-
-	old := env.Subject
-	env.Subject = result.Subject
-
-	hdr := mail.Header{
-		Name: "Subject",
-		Body: result.Subject,
-	}
-
-	if err := mail.ReplaceHeader(mailFilepath, hdr); err != nil {
-		return fmt.Errorf("replacing subject header failed: %w", err)
-	}
-
-	logger.Debug("rspamd returned modified subject",
-		"old_subject", old,
-		"new_subject", env.Subject,
-	)
-
-	return nil
-}
-
 // replaceWithModifiedMails uploads mails to the spam or inbox mailbox, depending on their
 // spam score.
 // The original email is moved to the backup mailbox.
@@ -387,9 +362,19 @@ func (c *Client) downloadAndScan(msg *imapclt.Message) (*scannedMail, error) {
 		return nil, fmt.Errorf("closing file of downloaded mail failed: %w", err)
 	}
 
-	err = rewriteSubject(tmpFile.Name(), env, scanResult, logger)
-	if err != nil {
-		return nil, err
+	if scanResult.Subject != "" && scanResult.Subject != env.Subject {
+		err := mail.ReplaceHeader(
+			tmpFile.Name(),
+			mail.Header{Name: "Subject", Body: scanResult.Subject},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("rewriting subject failed: %w", err)
+		}
+
+		logger.Debug("rewrote mail subject",
+			"mail.subject.old", env.Subject,
+			"mail.subject.new", scanResult.Subject,
+		)
 	}
 
 	err = addScanResultHeaders(tmpFile.Name(), scanResult)

--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -227,6 +227,17 @@ func (c *Client) isSpam(r *rspamc.CheckResult) bool {
 	return r.Score >= c.spamTreshold
 }
 
+func handleSubjectRewrite(env *imapclt.Envelope, scanResult *rspamc.CheckResult, logger *slog.Logger) {
+	if scanResult.Subject != "" && scanResult.Subject != env.Subject {
+		old := env.Subject
+		env.Subject = scanResult.Subject
+		logger.Debug("rspamd returned modified subject",
+			"old_subject", old,
+			"new_subject", env.Subject,
+		)
+	}
+}
+
 // replaceWithModifiedMails uploads mails to the spam or inbox mailbox, depending on their
 // spam score.
 // The original email is moved to the backup mailbox.
@@ -352,6 +363,8 @@ func (c *Client) downloadAndScan(msg *imapclt.Message) (*scannedMail, error) {
 		errCleanupfn()
 		return nil, fmt.Errorf("closing file of downloaded mail failed: %w", err)
 	}
+
+	handleSubjectRewrite(env, scanResult, logger)
 
 	err = addScanResultHeaders(tmpFile.Name(), scanResult)
 	if err != nil {

--- a/internal/iscan/client_test.go
+++ b/internal/iscan/client_test.go
@@ -110,13 +110,16 @@ func TestRun(t *testing.T) {
 	err = clt2.clt.Upload(mail.TestSpamMailPath(t), srv.ScanMailbox, time.Now())
 	assert.NoError(t, err)
 
+	err = clt2.clt.Upload(mail.TestSuspiciousMailPath(t), srv.ScanMailbox, time.Now())
+	assert.NoError(t, err)
+
 	err = clt2.clt.Upload(mail.TestHamMailPath(t), srv.HamMailbox, time.Now())
 	assert.NoError(t, err)
 
 	err = clt2.clt.Upload(mail.TestSpamMailPath(t), srv.UndetectedMailbox, time.Now())
 	assert.NoError(t, err)
 
-	for clt.cntProcessedMails.Load() < 4 {
+	for clt.cntProcessedMails.Load() < 5 {
 		time.Sleep(50 * time.Millisecond)
 	}
 
@@ -131,12 +134,20 @@ func TestRun(t *testing.T) {
 		mailboxContainsMailCnt(t, clt2.clt, clt.backupMailbox, mail.SpamMailSubject),
 	)
 
+	assert.Equal(t, 1,
+		mailboxContainsMailCnt(t, clt2.clt, clt.backupMailbox, mail.SuspiciousMailSubject),
+	)
+
 	assert.Equal(t, 2,
 		mailboxContainsMailCnt(t, clt2.clt, clt.inboxMailbox, mail.HamMailSubject),
 	)
 
 	assert.Equal(t, 2,
 		mailboxContainsMailCnt(t, clt2.clt, clt.spamMailbox, mail.SpamMailSubject),
+	)
+
+	assert.Equal(t, 1, 
+		mailboxContainsMailCnt(t, clt2.clt, clt.inboxMailbox, mail.SuspiciousMailRewrittenSubject),
 	)
 
 	assert.NoError(t, clt.Stop())

--- a/internal/iscan/client_test.go
+++ b/internal/iscan/client_test.go
@@ -146,7 +146,7 @@ func TestRun(t *testing.T) {
 		mailboxContainsMailCnt(t, clt2.clt, clt.spamMailbox, mail.SpamMailSubject),
 	)
 
-	assert.Equal(t, 1, 
+	assert.Equal(t, 1,
 		mailboxContainsMailCnt(t, clt2.clt, clt.inboxMailbox, mail.SuspiciousMailRewrittenSubject),
 	)
 

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -168,17 +168,20 @@ func ReplaceHeader(path string, hdr Header) error {
 	if err != nil {
 		return err
 	}
+
 	emailFd, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer emailFd.Close()
+
 	err = replaceHeader(emailFd, tmpfileFd, hdr)
 	if err != nil {
 		_ = tmpfileFd.Close()
 		delErr := os.Remove(tmpfileFd.Name())
 		return errors.Join(err, delErr)
 	}
+
 	if err := tmpfileFd.Close(); err != nil {
 		delErr := os.Remove(tmpfileFd.Name())
 		return errors.Join(
@@ -186,6 +189,7 @@ func ReplaceHeader(path string, hdr Header) error {
 			delErr,
 		)
 	}
+
 	return os.Rename(tmpfileFd.Name(), path)
 }
 
@@ -212,9 +216,11 @@ func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
 			if !replaced {
 				return fmt.Errorf("header %q not found", hdr.Name)
 			}
+
 			if _, err := tmpfileBw.Write([]byte("\r\n")); err != nil {
 				return fmt.Errorf("writing failed: %w", err)
 			}
+
 			headerEnded = true
 			continue // Continue to copy body lines
 		}
@@ -235,9 +241,9 @@ func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
 		if skipContinuation {
 			if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
 				continue // Skip physical continuation line
-			} else {
-				skipContinuation = false // Stop skipping; this line belongs to the next section/header
 			}
+
+			skipContinuation = false // Stop skipping; this line belongs to the next section/header
 		}
 
 		if !replaced && bytes.HasPrefix(bytes.ToUpper(line), bytes.ToUpper(prefix)) {
@@ -264,6 +270,7 @@ func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
 	if err := tmpfileBw.Flush(); err != nil {
 		return fmt.Errorf("flushing buffer failed: %w", err)
 	}
+
 	return nil
 }
 

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -163,7 +163,6 @@ func addHeaders(in io.Reader, out io.Writer, hdrs []byte) error {
 }
 
 // ReplaceHeader replaces the first occurrence of a header in the e-mail at [path].
-// The file must be in RFC2822 format.
 func ReplaceHeader(path string, hdr Header) error {
 	tmpfileFd, err := os.CreateTemp("", filepath.Base(path))
 	if err != nil {
@@ -191,7 +190,7 @@ func ReplaceHeader(path string, hdr Header) error {
 }
 
 // replaceHeader reads an email from in, replaces the first occurrence of the
-// named header and writes the result to out.
+// named header (with RFC5322 multiline folding support) and writes the result to out.
 func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
 	emailBr := bufio.NewReader(in)
 	tmpfileBw := bufio.NewWriter(out)
@@ -199,13 +198,16 @@ func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
 	prefix := []byte(hdr.Name + ":")
 	replacement := []byte(hdr.Name + ": " + hdr.Body + "\r\n")
 	replaced := false
+	skipContinuation := false // true when skipping FWS continuation lines of the old header
+	headerEnded := false      // true after the blank line separator is found
 
 	lineScanner := bufio.NewScanner(emailBr)
-	lineScanner.Buffer(make([]byte, 4096), 4096)
+	lineScanner.Buffer(make([]byte, 0, 4096), 16384)
+
 	for lineScanner.Scan() {
 		line := lineScanner.Bytes()
 
-		// Blank line signals end of headers (Scanner strips \r\n, so empty == \r\n line)
+		// Blank line signals end of headers (Scanner strips \r\n, so empty == \r\n\r\n)
 		if len(line) == 0 {
 			if !replaced {
 				return fmt.Errorf("header %q not found", hdr.Name)
@@ -213,15 +215,40 @@ func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
 			if _, err := tmpfileBw.Write([]byte("\r\n")); err != nil {
 				return fmt.Errorf("writing failed: %w", err)
 			}
-			break
+			headerEnded = true
+			continue // Continue to copy body lines
+		}
+
+		// Once headers have ended, we're in the body - just copy lines as-is
+		if headerEnded {
+			if _, err := tmpfileBw.Write(line); err != nil {
+				return fmt.Errorf("copying data failed: %w", err)
+			}
+			if _, err := tmpfileBw.Write([]byte("\r\n")); err != nil {
+				return fmt.Errorf("copying data failed: %w", err)
+			}
+			continue
+		}
+
+		// Skip continuation lines, if currently inside the replaced header block.
+		// Per RFC5322 §2.2.3, folded lines must start with whitespace (FWS).
+		if skipContinuation {
+			if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+				continue // Skip physical continuation line
+			} else {
+				skipContinuation = false // Stop skipping; this line belongs to the next section/header
+			}
 		}
 
 		if !replaced && bytes.HasPrefix(bytes.ToUpper(line), bytes.ToUpper(prefix)) {
+			// Found the target header (first line of a possible folded sequence)
+			skipContinuation = true
 			if _, err := tmpfileBw.Write(replacement); err != nil {
 				return fmt.Errorf("writing failed: %w", err)
 			}
 			replaced = true
 		} else {
+			// Normal line, copy it to output
 			if _, err := tmpfileBw.Write(line); err != nil {
 				return fmt.Errorf("copying data failed: %w", err)
 			}
@@ -234,9 +261,6 @@ func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
 		return fmt.Errorf("reading email failed: %w", err)
 	}
 
-	if _, err := io.Copy(tmpfileBw, emailBr); err != nil {
-		return fmt.Errorf("copying email failed: %w", err)
-	}
 	if err := tmpfileBw.Flush(); err != nil {
 		return fmt.Errorf("flushing buffer failed: %w", err)
 	}

--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -162,6 +162,87 @@ func addHeaders(in io.Reader, out io.Writer, hdrs []byte) error {
 	return nil
 }
 
+// ReplaceHeader replaces the first occurrence of a header in the e-mail at [path].
+// The file must be in RFC2822 format.
+func ReplaceHeader(path string, hdr Header) error {
+	tmpfileFd, err := os.CreateTemp("", filepath.Base(path))
+	if err != nil {
+		return err
+	}
+	emailFd, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer emailFd.Close()
+	err = replaceHeader(emailFd, tmpfileFd, hdr)
+	if err != nil {
+		_ = tmpfileFd.Close()
+		delErr := os.Remove(tmpfileFd.Name())
+		return errors.Join(err, delErr)
+	}
+	if err := tmpfileFd.Close(); err != nil {
+		delErr := os.Remove(tmpfileFd.Name())
+		return errors.Join(
+			fmt.Errorf("writing tempfile failed: %w", err),
+			delErr,
+		)
+	}
+	return os.Rename(tmpfileFd.Name(), path)
+}
+
+// replaceHeader reads an email from in, replaces the first occurrence of the
+// named header and writes the result to out.
+func replaceHeader(in io.Reader, out io.Writer, hdr Header) error {
+	emailBr := bufio.NewReader(in)
+	tmpfileBw := bufio.NewWriter(out)
+
+	prefix := []byte(hdr.Name + ":")
+	replacement := []byte(hdr.Name + ": " + hdr.Body + "\r\n")
+	replaced := false
+
+	lineScanner := bufio.NewScanner(emailBr)
+	lineScanner.Buffer(make([]byte, 4096), 4096)
+	for lineScanner.Scan() {
+		line := lineScanner.Bytes()
+
+		// Blank line signals end of headers (Scanner strips \r\n, so empty == \r\n line)
+		if len(line) == 0 {
+			if !replaced {
+				return fmt.Errorf("header %q not found", hdr.Name)
+			}
+			if _, err := tmpfileBw.Write([]byte("\r\n")); err != nil {
+				return fmt.Errorf("writing failed: %w", err)
+			}
+			break
+		}
+
+		if !replaced && bytes.HasPrefix(bytes.ToUpper(line), bytes.ToUpper(prefix)) {
+			if _, err := tmpfileBw.Write(replacement); err != nil {
+				return fmt.Errorf("writing failed: %w", err)
+			}
+			replaced = true
+		} else {
+			if _, err := tmpfileBw.Write(line); err != nil {
+				return fmt.Errorf("copying data failed: %w", err)
+			}
+			if _, err := tmpfileBw.Write([]byte("\r\n")); err != nil {
+				return fmt.Errorf("copying data failed: %w", err)
+			}
+		}
+	}
+	if err := lineScanner.Err(); err != nil {
+		return fmt.Errorf("reading email failed: %w", err)
+	}
+
+	if _, err := io.Copy(tmpfileBw, emailBr); err != nil {
+		return fmt.Errorf("copying email failed: %w", err)
+	}
+	if err := tmpfileBw.Flush(); err != nil {
+		return fmt.Errorf("flushing buffer failed: %w", err)
+	}
+	return nil
+}
+
 // strEmailHdrCharsOnly removes all non-printable ASCII chars and colons from s
 func strEmailHdrCharsOnly(s string) string {
 	return strings.Map(func(r rune) rune {

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -55,3 +55,35 @@ func TestAddHeaders(t *testing.T) {
 		t.Errorf("Got:\n%q\nExpected:\n%q\n", string(result), expected)
 	}
 }
+
+func TestReplaceHeader(t *testing.T) {
+	const expected = "From: newperson@example.com\r\nTo: someone_else@example.com\r\nSubject: An RFC 822 formatted message\r\n\r\nThis is the plain text body of the message. Note the blank line\r\nbetween the header information and the body of the message.\r\n"
+ 
+	tmpdir := t.TempDir()
+	fd, err := os.CreateTemp(tmpdir, t.Name())
+	AssertNoErr(t, err)
+ 
+	exampleFd, err := os.Open(mail.TestHamMailPath(t))
+	AssertNoErr(t, err)
+ 
+	_, err = io.Copy(fd, exampleFd)
+	AssertNoErr(t, err)
+ 
+	err = fd.Close()
+	AssertNoErr(t, err)
+	_ = exampleFd.Close()
+ 
+	// Replace the From header
+	err = ReplaceHeader(fd.Name(), Header{
+		Name: "From",
+		Body: "newperson@example.com",
+	})
+	AssertNoErr(t, err)
+ 
+	result, err := os.ReadFile(fd.Name())
+	AssertNoErr(t, err)
+ 
+	if !bytes.Equal(result, []byte(expected)) {
+		t.Errorf("Got:\n%q\nExpected:\n%q\n", string(result), expected)
+	}
+}

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -58,31 +58,31 @@ func TestAddHeaders(t *testing.T) {
 
 func TestReplaceHeader(t *testing.T) {
 	const expected = "From: newperson@example.com\r\nTo: someone_else@example.com\r\nSubject: An RFC 822 formatted message\r\n\r\nThis is the plain text body of the message. Note the blank line\r\nbetween the header information and the body of the message.\r\n"
- 
+
 	tmpdir := t.TempDir()
 	fd, err := os.CreateTemp(tmpdir, t.Name())
 	AssertNoErr(t, err)
- 
+
 	exampleFd, err := os.Open(mail.TestHamMailPath(t))
 	AssertNoErr(t, err)
- 
+
 	_, err = io.Copy(fd, exampleFd)
 	AssertNoErr(t, err)
- 
+
 	err = fd.Close()
 	AssertNoErr(t, err)
 	_ = exampleFd.Close()
- 
+
 	// Replace the From header
 	err = ReplaceHeader(fd.Name(), Header{
 		Name: "From",
 		Body: "newperson@example.com",
 	})
 	AssertNoErr(t, err)
- 
+
 	result, err := os.ReadFile(fd.Name())
 	AssertNoErr(t, err)
- 
+
 	if !bytes.Equal(result, []byte(expected)) {
 		t.Errorf("Got:\n%q\nExpected:\n%q\n", string(result), expected)
 	}

--- a/internal/rspamc/rspamc.go
+++ b/internal/rspamc/rspamc.go
@@ -110,9 +110,10 @@ type CheckResult struct {
 	Score     float32            `json:"score"`
 	IsSkipped bool               `json:"is_skipped"`
 	Symbols   map[string]*Symbol `json:"symbols"`
+	Subject   string             `json:"subject,omitempty"`
 }
 
-// https://rspamd.com/doc/architecture/protocol.html#protocol-basics
+// https://docs.rspamd.com/developers/protocol#protocol-basics
 type Symbol struct {
 	Name  string  `json:"name"`
 	Score float32 `json:"score"`

--- a/internal/testutils/mail/mail.go
+++ b/internal/testutils/mail/mail.go
@@ -7,10 +7,10 @@ import (
 )
 
 const (
-	SpamMailSubject = "Test spam mail (GTUBE)"
-	SuspiciousMailSubject = "Claim your FREE reward NOW!!!"
+	SpamMailSubject                = "Test spam mail (GTUBE)"
+	SuspiciousMailSubject          = "Claim your FREE reward NOW!!!"
 	SuspiciousMailRewrittenSubject = "[SPAM] Claim your FREE reward NOW!!!"
-	HamMailSubject  = "An RFC 822 formatted message"
+	HamMailSubject                 = "An RFC 822 formatted message"
 )
 
 func findProjectRoot(t *testing.T) string {

--- a/internal/testutils/mail/mail.go
+++ b/internal/testutils/mail/mail.go
@@ -8,6 +8,8 @@ import (
 
 const (
 	SpamMailSubject = "Test spam mail (GTUBE)"
+	SuspiciousMailSubject = "Claim your FREE reward NOW!!!"
+	SuspiciousMailRewrittenSubject = "[SPAM] Claim your FREE reward NOW!!!"
 	HamMailSubject  = "An RFC 822 formatted message"
 )
 
@@ -47,6 +49,11 @@ func TestHamMailPath(t *testing.T) string {
 func TestSpamMailPath(t *testing.T) string {
 	proot := findProjectRoot(t)
 	return filepath.Join(proot, "internal", "testutils", "mail", "testdata", "spam.mail")
+}
+
+func TestSuspiciousMailPath(t *testing.T) string {
+	proot := findProjectRoot(t)
+	return filepath.Join(proot, "internal", "testutils", "mail", "testdata", "suspicious.mail")
 }
 
 func TestMalformedMailPath(t *testing.T) string {

--- a/internal/testutils/mail/testdata/suspicious.mail
+++ b/internal/testutils/mail/testdata/suspicious.mail
@@ -1,0 +1,7 @@
+Subject: Claim your FREE reward NOW!!!
+Date: Wed, 23 Jul 2026 23:30:00 +0200
+From: deals@example.net
+To: recipient@example.com
+
+Congratulations!! You have been SELECTED for a FREE reward worth $500.
+Click here to claim: http://example.com/claim?id=839201

--- a/internal/testutils/mock/rspamc.go
+++ b/internal/testutils/mock/rspamc.go
@@ -21,6 +21,11 @@ var SpamCheckResult = rspamc.CheckResult{
 	Score: 100,
 }
 
+var SubjectRewriteResult = rspamc.CheckResult{
+	Score: 6,
+	Subject: "[SPAM] Claim your FREE reward NOW!!!",
+}
+
 // func CheckFnAlwaysSpam(context.Context, io.Reader, *rspamc.MailHeaders) (
 // 	*rspamc.CheckResult, error,
 // ) {
@@ -33,6 +38,8 @@ func CheckFnDefault(_ context.Context, _ io.Reader, hdr *rspamc.MailHeaders) (
 	switch hdr.Subject {
 	case "Test spam mail (GTUBE)":
 		return &SpamCheckResult, nil
+	case "Claim your FREE reward NOW!!!":
+		return &SubjectRewriteResult, nil
 	default:
 		return &rspamc.CheckResult{}, nil
 	}

--- a/internal/testutils/mock/rspamc.go
+++ b/internal/testutils/mock/rspamc.go
@@ -22,7 +22,7 @@ var SpamCheckResult = rspamc.CheckResult{
 }
 
 var SubjectRewriteResult = rspamc.CheckResult{
-	Score: 6,
+	Score:   6,
 	Subject: "[SPAM] Claim your FREE reward NOW!!!",
 }
 


### PR DESCRIPTION
I tried my hand at implementing subject rewriting as discussed in https://github.com/fho/rspamd-iscan/issues/19.

The [official docs](https://docs.rspamd.com/developers/protocol/#rspamd-http-reply) state that when the action is `rewrite subject`, the new subject will be sent as a simple `subject` key.

I did try this with a dry-run and real mails which modified the mails correctly. I also expanded the `TestRun` test to the best of my ability which still successfully completes.

Please note that this was my first experience with Go and I did use AI for parts of the code.