### PR TITLE
Optionally mark undetected messages as read

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,28 +73,30 @@ Create a new configuration file with the following content and adapt it to your
 setup:
 
 ```toml
-RspamdURL           = "http://192.168.178.2:11334"
-RspamdPassword      = "iwonttellyou"
-ImapAddr            = "my-imap-server:993"
-ImapUser            = "rickdeckard"
-ImapPassword        = "zhora"
-InboxMailbox        = "INBOX"
-SpamMailbox         = "Spam"
-HamMailbox          = "Ham"
-UndetectedMailbox   = "Undetected"
-BackupMailbox       = "Backup"
+RspamdURL               = "http://192.168.178.2:11334"
+RspamdPassword          = "iwonttellyou"
+ImapAddr                = "my-imap-server:993"
+ImapUser                = "rickdeckard"
+ImapPassword            = "zhora"
+InboxMailbox            = "INBOX"
+SpamMailbox             = "Spam"
+HamMailbox              = "Ham"
+UndetectedMailbox       = "Undetected"
+BackupMailbox           = "Backup"
 # TempDir stores downloaded mails and their modified variants with added spam
 # headers
-TempDir             = "/tmp"
+TempDir                 = "/tmp"
 # Set KeepTempFiles to false to delete temporary files after use immediately
-KeepTempFiles       = true
-ScanMailbox         = "Unscanned"
+KeepTempFiles           = true
+ScanMailbox             = "Unscanned"
 # Mails with a higher or equal rspamd score than SpamThreshold are moved to
 # SpamMailbox, others to HamMailbox
-SpamThreshold       = 10.0
+SpamThreshold           = 10.0
 # Raw incoming and outgoing IMAP data is logged with debug log level.
 # The logged data can contain sensitive information, like credentials.
-LogIMAPData         = false
+LogIMAPData             = false
+# Mark mails in UndetectedMailbox as read when moving them to SpamMailbox.
+MarkLearnedAsSpamAsRead = false
 ```
 
 ### Credentials Directory

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ func (c *Config) String() string {
 	printKv("Temporary Directory", c.TempDir)
 	printKv("Keep Temporary Files", c.KeepTempFiles)
 	printKv("Log IMAP Data", c.LogIMAPData)
-	printKv("Mark Undetected As Read", c.MarkLearnedAsSpamAsRead)
+	printKv("Mark Learned Spam as Read", c.MarkLearnedAsSpamAsRead)
 
 	sb.WriteRune('\n')
 	fmt.Fprintf(&sb, "Mails in %q are scanned and backuped to %q.\n", c.ScanMailbox, c.BackupMailbox)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,21 +10,22 @@ import (
 )
 
 type Config struct {
-	RspamdURL         string
-	RspamdPassword    string
-	ImapAddr          string
-	ImapUser          string
-	ImapPassword      string
-	InboxMailbox      string
-	SpamMailbox       string
-	ScanMailbox       string
-	HamMailbox        string
-	BackupMailbox     string
-	UndetectedMailbox string
-	SpamThreshold     float32
-	TempDir           string
-	KeepTempFiles     bool
-	LogIMAPData       bool
+	RspamdURL               string
+	RspamdPassword          string
+	ImapAddr                string
+	ImapUser                string
+	ImapPassword            string
+	InboxMailbox            string
+	SpamMailbox             string
+	ScanMailbox             string
+	HamMailbox              string
+	BackupMailbox           string
+	UndetectedMailbox       string
+	SpamThreshold           float32
+	TempDir                 string
+	KeepTempFiles           bool
+	LogIMAPData             bool
+	MarkLearnedAsSpamAsRead bool
 }
 
 func (c *Config) String() string {
@@ -63,6 +64,7 @@ func (c *Config) String() string {
 	printKv("Temporary Directory", c.TempDir)
 	printKv("Keep Temporary Files", c.KeepTempFiles)
 	printKv("Log IMAP Data", c.LogIMAPData)
+	printKv("Mark Undetected As Read", c.MarkLearnedAsSpamAsRead)
 
 	sb.WriteRune('\n')
 	fmt.Fprintf(&sb, "Mails in %q are scanned and backuped to %q.\n", c.ScanMailbox, c.BackupMailbox)

--- a/internal/imapclt/client.go
+++ b/internal/imapclt/client.go
@@ -279,6 +279,32 @@ func (c *Client) Move(uids []uint32, mailbox string) error {
 	return err
 }
 
+// MarkSeen adds the \Seen flag to the messages with the given UIDs in the
+// currently selected mailbox.
+func (c *Client) MarkSeen(uids []uint32) error {
+	if len(uids) == 0 {
+		return errors.New("no uids were given")
+	}
+
+	storeCmd := c.clt.Store(asUIDSet(uids), &imap.StoreFlags{
+		Op:     imap.StoreFlagsAdd,
+		Silent: true,
+		Flags:  []imap.Flag{imap.FlagSeen},
+	}, nil)
+
+	if err := storeCmd.Close(); err != nil {
+		return fmt.Errorf("marking messages as seen failed: %w", err)
+	}
+
+	c.logger.Debug(
+		"marked imap messages as seen",
+		"count", len(uids),
+		"event", "imap.messages_marked_seen",
+	)
+
+	return nil
+}
+
 func (c *Client) setNewMessagesCH(ch chan<- *EventNewMessages) {
 	c.mu.Lock()
 	c.newMessagesCh = ch

--- a/internal/imapclt/dry_client.go
+++ b/internal/imapclt/dry_client.go
@@ -29,3 +29,11 @@ func (c *DryClient) Move(uids []uint32, mailbox string) error {
 	)
 	return nil
 }
+
+// MarkSeen logs a debug message and returns nil
+func (c *DryClient) MarkSeen(uids []uint32) error {
+	c.logger.Debug("dry-client: skipping marking messages as seen",
+		"count", len(uids),
+	)
+	return nil
+}

--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -51,6 +51,8 @@ type Client struct {
 	tempDir       string
 	keepTempFiles bool
 
+	markLearnedAsSpamAsRead bool
+
 	learnInterval time.Duration
 
 	// cntProcessedMails counts the number of emails that have been processed
@@ -75,20 +77,21 @@ func NewClient(cfg *Config) (*Client, error) {
 	}
 
 	c := &Client{
-		clt:               cfg.IMAPClient,
-		logger:            log.EnsureLoggerInstance(cfg.Logger),
-		inboxMailbox:      cfg.InboxMailbox,
-		scanMailbox:       cfg.ScanMailbox,
-		spamMailbox:       cfg.SpamMailboxName,
-		hamMailbox:        cfg.HamMailbox,
-		undetectedMailbox: cfg.UndetectedMailboxName,
-		rspamc:            cfg.Rspamc,
-		spamTreshold:      cfg.SpamTreshold,
-		learnInterval:     30 * time.Minute,
-		backupMailbox:     cfg.BackupMailbox,
-		tempDir:           cfg.TempDir,
-		keepTempFiles:     cfg.KeepTempFiles,
-		stopCh:            make(chan struct{}),
+		clt:                     cfg.IMAPClient,
+		logger:                  log.EnsureLoggerInstance(cfg.Logger),
+		inboxMailbox:            cfg.InboxMailbox,
+		scanMailbox:             cfg.ScanMailbox,
+		spamMailbox:             cfg.SpamMailboxName,
+		hamMailbox:              cfg.HamMailbox,
+		undetectedMailbox:       cfg.UndetectedMailboxName,
+		rspamc:                  cfg.Rspamc,
+		spamTreshold:            cfg.SpamTreshold,
+		learnInterval:           30 * time.Minute,
+		backupMailbox:           cfg.BackupMailbox,
+		tempDir:                 cfg.TempDir,
+		keepTempFiles:           cfg.KeepTempFiles,
+		markLearnedAsSpamAsRead: cfg.MarkLearnedAsSpamAsRead,
+		stopCh:                  make(chan struct{}),
 	}
 
 	return c, nil
@@ -99,7 +102,7 @@ func (c *Client) ProcessHam() error {
 		return nil
 	}
 
-	return c.learn(c.hamMailbox, c.inboxMailbox, c.rspamc.Ham)
+	return c.learn(c.hamMailbox, c.inboxMailbox, false, c.rspamc.Ham)
 }
 
 func (c *Client) ProcessSpam() error {
@@ -107,10 +110,10 @@ func (c *Client) ProcessSpam() error {
 		return nil
 	}
 
-	return c.learn(c.undetectedMailbox, c.spamMailbox, c.rspamc.Spam)
+	return c.learn(c.undetectedMailbox, c.spamMailbox, c.markLearnedAsSpamAsRead, c.rspamc.Spam)
 }
 
-func (c *Client) learn(srcMailbox, destMailbox string, learnFn learnFn) error {
+func (c *Client) learn(srcMailbox, destMailbox string, markAsSeen bool, learnFn learnFn) error {
 	var processedMsgUIDs []uint32
 
 	logger := c.logger.With("mailbox.source", srcMailbox)
@@ -154,6 +157,12 @@ func (c *Client) learn(srcMailbox, destMailbox string, learnFn learnFn) error {
 
 	if len(processedMsgUIDs) == 0 {
 		return nil
+	}
+
+	if markAsSeen {
+		if err := c.clt.MarkSeen(processedMsgUIDs); err != nil {
+			return fmt.Errorf("marking messages as seen failed: %w", err)
+		}
 	}
 
 	err := c.clt.Move(processedMsgUIDs, destMailbox)

--- a/internal/iscan/config.go
+++ b/internal/iscan/config.go
@@ -14,6 +14,7 @@ import (
 type IMAPClient interface {
 	Close() error
 	Connect() error
+	MarkSeen(uids []uint32) error
 	Messages(mailbox string) iter.Seq2[*imapclt.Message, error]
 	Monitor(mailbox string) (<-chan *imapclt.EventNewMessages, func() error, error)
 	Move(uids []uint32, mailbox string) error
@@ -30,6 +31,8 @@ type Config struct {
 
 	TempDir       string
 	KeepTempFiles bool
+
+	MarkLearnedAsSpamAsRead bool
 
 	SpamTreshold float32
 

--- a/main.go
+++ b/main.go
@@ -136,18 +136,19 @@ func newIscanClient(
 	imapClt iscan.IMAPClient,
 ) (*iscan.Client, error) {
 	iscanCfg := iscan.Config{
-		ScanMailbox:           cfg.ScanMailbox,
-		InboxMailbox:          cfg.InboxMailbox,
-		HamMailbox:            cfg.HamMailbox,
-		SpamMailboxName:       cfg.SpamMailbox,
-		UndetectedMailboxName: cfg.UndetectedMailbox,
-		BackupMailbox:         cfg.BackupMailbox,
-		SpamTreshold:          cfg.SpamThreshold,
-		TempDir:               cfg.TempDir,
-		KeepTempFiles:         cfg.KeepTempFiles,
-		Logger:                logger,
-		Rspamc:                rspamc,
-		IMAPClient:            imapClt,
+		ScanMailbox:             cfg.ScanMailbox,
+		InboxMailbox:            cfg.InboxMailbox,
+		HamMailbox:              cfg.HamMailbox,
+		SpamMailboxName:         cfg.SpamMailbox,
+		UndetectedMailboxName:   cfg.UndetectedMailbox,
+		BackupMailbox:           cfg.BackupMailbox,
+		SpamTreshold:            cfg.SpamThreshold,
+		TempDir:                 cfg.TempDir,
+		KeepTempFiles:           cfg.KeepTempFiles,
+		MarkLearnedAsSpamAsRead: cfg.MarkLearnedAsSpamAsRead,
+		Logger:                  logger,
+		Rspamc:                  rspamc,
+		IMAPClient:              imapClt,
 	}
 
 	return iscan.NewClient(&iscanCfg)


### PR DESCRIPTION
Add config item to mark undetected messages as read when moved to spam folder. Defaults to `false`, so should be a non-breaking change.