### PR TITLE
Update go and golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: build
         run: make build

--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/golangcilint.yml
+++ b/.github/workflows/golangcilint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.8
+          version: v2.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: test
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - modernize
     - nolintlint
     - nosprintfhostport
     - prealloc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fho/rspamd-iscan
 
-go 1.25.6
+go 1.26.3
 
 require (
 	github.com/emersion/go-imap/v2 v2.0.0-beta.7

--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -265,7 +265,7 @@ func (c *Client) replaceWithModifiedMails(mails []*scannedMail) error {
 		err = c.clt.Upload(mail.Path, mbox, mail.Envelope.Date)
 		if err != nil {
 			errs = append(errs, fmt.Errorf(
-				"uploading email %q (%s) (%s) to %s failed: %w",
+				"uploading email %d (%s) (%s) to %s failed: %w",
 				mail.UID, mail.Envelope.Subject, mail.Path, mbox, err,
 			))
 			logger.Warn(

--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -119,8 +119,7 @@ func (c *Client) learn(srcMailbox, destMailbox string, learnFn learnFn) error {
 
 	for msg, err := range c.clt.Messages(srcMailbox) {
 		if err != nil {
-			var errMalformed *imapclt.ErrMalformedMsg
-			if errors.As(err, &errMalformed) {
+			if errMalformed, ok := errors.AsType[*imapclt.ErrMalformedMsg](err); ok {
 				logger.Warn("skipping malformed message",
 					"mail.uid", errMalformed.UID,
 					"error", err,
@@ -388,8 +387,7 @@ func (c *Client) ProcessScanBox() error {
 
 	for msg, err := range c.clt.Messages(c.scanMailbox) {
 		if err != nil {
-			var errMalformed *imapclt.ErrMalformedMsg
-			if errors.As(err, &errMalformed) {
+			if errMalformed, ok := errors.AsType[*imapclt.ErrMalformedMsg](err); ok {
 				logger.Warn("email is malformed, skipping scan",
 					"mail.uid", errMalformed.UID,
 					"error", err,


### PR DESCRIPTION
```
iscan: use errors.AsType

use the new errors.AsType helper when possible

-------------------------------------------------------------------------------
ci: enable modernize golangci-lint linter

-------------------------------------------------------------------------------
fix: wrong printf type specifier in error message

This fixes:
        internal/iscan/client.go:268:22: printf: fmt.Errorf format %q
        has arg mail.UID of wrong type uint32 (govet)
        "uploading email %q (%s) (%s) to %s failed: %w",

-------------------------------------------------------------------------------
update go to 1.26.3

-------------------------------------------------------------------------------
```