### PR TITLE
config: enable MarkLearnedAsSpamAsRead by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ SpamThreshold           = 10.0
 # The logged data can contain sensitive information, like credentials.
 LogIMAPData             = false
 # Mark mails in UndetectedMailbox as read when moving them to SpamMailbox.
-MarkLearnedAsSpamAsRead = false
+MarkLearnedAsSpamAsRead = true
 ```
 
 ### Credentials Directory
 
 Instead of storing sensitive credentials directly in the config file, you can use
-the `--credentials-directory` flag to specify a directory containing credential files.
-This is compatible with [systemd credentials](https://systemd.io/CREDENTIALS/).
+the `--credentials-directory` flag to specify a directory containing credential
+files. This is compatible with [systemd credentials](https://systemd.io/CREDENTIALS/).
 
 If the credentials directory is set, rspamd-iscan looks for files named after the
 config fields: `RspamdURL`, `RspamdPassword`, `ImapUser`, `ImapPassword`. If a file

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ BackupMailbox           = "Backup"
 # headers
 TempDir                 = "/tmp"
 # Set KeepTempFiles to false to delete temporary files after use immediately
-KeepTempFiles           = true
+KeepTempFiles           = false
 ScanMailbox             = "Unscanned"
 # Mails with a higher or equal rspamd score than SpamThreshold are moved to
 # SpamMailbox, others to HamMailbox

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,13 @@ type Config struct {
 	MarkLearnedAsSpamAsRead bool
 }
 
+// New returns an new config initialized with default values
+func New() *Config {
+	return &Config{
+		TempDir: os.TempDir(),
+	}
+}
+
 func (c *Config) String() string {
 	const unset = "UNSET"
 	const hiddenPasswd = "***"
@@ -79,23 +86,18 @@ func (c *Config) String() string {
 }
 
 func FromFile(path string) (*Config, error) {
-	var result Config
+	result := New()
+
 	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	err = toml.Unmarshal(buf, &result)
+	err = toml.Unmarshal(buf, result)
 	if err != nil {
 		return nil, err
 	}
 
-	return &result, nil
-}
-
-func (c *Config) SetDefaults() {
-	if c.TempDir == "" {
-		c.TempDir = os.TempDir()
-	}
+	return result, nil
 }
 
 // LoadCredentialsFromDirectory reads credentials from files in the specified

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,8 @@ type Config struct {
 // New returns an new config initialized with default values
 func New() *Config {
 	return &Config{
-		TempDir: os.TempDir(),
+		TempDir:                 os.TempDir(),
+		MarkLearnedAsSpamAsRead: true,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,3 +65,15 @@ func TestLoadCredentialsFromDirectory_PreservesSpaces(t *testing.T) {
 	assert.Equal(t, " spaces \nnewline", cfg.RspamdPassword)
 	assert.Equal(t, " spaces \r\nnewline", cfg.ImapPassword)
 }
+
+func TestDefaults(t *testing.T) {
+	dir := t.TempDir()
+
+	f := filepath.Join(dir, "cfg.toml")
+	assert.NoError(t, os.WriteFile(f, []byte{}, 0o600))
+
+	cfg, err := FromFile(f)
+	assert.NoError(t, err)
+
+	assert.Equal(t, cfg.TempDir, os.TempDir())
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,4 +76,5 @@ func TestDefaults(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, cfg.TempDir, os.TempDir())
+	assert.Equal(t, cfg.MarkLearnedAsSpamAsRead, true)
 }

--- a/main.go
+++ b/main.go
@@ -221,7 +221,6 @@ func run() error {
 		}
 	}
 
-	cfg.SetDefaults()
 	fmt.Print(cfg.String())
 
 	// TODO: allow passing all attrs as single URL to rspamc http client


### PR DESCRIPTION
```
config: enable MarkLearnedAsSpamAsRead by default

It's a handy feature that makes live a bit easier when enabled.
Sometimes it is clear that a message is spam by only reading the
subject.
When moving them to the UndetectedMailbox they will show-up as read
later in the Spam mailbox. When checking periodically the spam mailbox,
they show up as read and indiciated that their spam status does not have
to be verified manually again.

-------------------------------------------------------------------------------
test: add test for verifying config default values

Add a testcase that verifies that cfg values, where their documented
default isn't the same as the default value for the type, have the
expected value when not set.

The implementation is also slightly refactored, the defaults are not set
in the struct before unmarshaling. Calling SetDefaults in main is not
needed anymore.

-------------------------------------------------------------------------------
docs: fix: KeepTempFiles default is false not true

The README.md states that the default value for KeepTempFiles is true
but it is false, false is also the better default. Keeping those files
is only needed for debugging.

-------------------------------------------------------------------------------
```