### PR TITLE
iscan: don't fail if marking message as seen during learn failed

### DIFF
--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -160,7 +160,8 @@ func (c *Client) learn(srcMailbox, destMailbox string, markAsSeen bool, learnFn 
 
 	if markAsSeen {
 		if err := c.clt.MarkSeen(processedMsgUIDs); err != nil {
-			return fmt.Errorf("marking messages as seen failed: %w", err)
+			logger.Warn("marking learned message as seen failed",
+				"error", err)
 		}
 	}
 


### PR DESCRIPTION
Marking a message as seen when learning it as spam is not critical. In the unlikely case that it fails, print a warning and continue instead of terminating the application.