### PR TITLE
config: make log level configurable & support logging full http rspamd responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ ScanMailbox             = "Unscanned"
 # Mails with a higher or equal rspamd score than SpamThreshold are moved to
 # SpamMailbox, others to HamMailbox
 SpamThreshold           = 10.0
+# Minimal severity of log messages to be printed,
+# supported levels: debug, info, warn, error
+LogLevel                = "info"
 # Raw incoming and outgoing IMAP data is logged with debug log level.
 # The logged data can contain sensitive information, like credentials.
 LogIMAPData             = false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,13 +26,15 @@ type Config struct {
 	KeepTempFiles           bool
 	LogIMAPData             bool
 	MarkLearnedAsSpamAsRead bool
+	LogLevel                string
 }
 
 // New returns an new config initialized with default values
 func New() *Config {
 	return &Config{
-		TempDir:                 os.TempDir(),
+		LogLevel:                "info",
 		MarkLearnedAsSpamAsRead: true,
+		TempDir:                 os.TempDir(),
 	}
 }
 
@@ -69,10 +71,12 @@ func (c *Config) String() string {
 	printKv("Spam Mailbox", c.SpamMailbox)
 	printKv("Undetected Mailbox", c.UndetectedMailbox)
 	printKv("Backup Mailbox", c.BackupMailbox)
+	printKv("Mark Learned Spam as Read", c.MarkLearnedAsSpamAsRead)
+
 	printKv("Temporary Directory", c.TempDir)
 	printKv("Keep Temporary Files", c.KeepTempFiles)
 	printKv("Log IMAP Data", c.LogIMAPData)
-	printKv("Mark Learned Spam as Read", c.MarkLearnedAsSpamAsRead)
+	printKv("Log Level", c.LogLevel)
 
 	sb.WriteRune('\n')
 	fmt.Fprintf(&sb, "Mails in %q are scanned and backuped to %q.\n", c.ScanMailbox, c.BackupMailbox)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -77,4 +77,5 @@ func TestDefaults(t *testing.T) {
 
 	assert.Equal(t, cfg.TempDir, os.TempDir())
 	assert.Equal(t, cfg.MarkLearnedAsSpamAsRead, true)
+	assert.Equal(t, cfg.LogLevel, "info")
 }

--- a/internal/iscan/client.go
+++ b/internal/iscan/client.go
@@ -160,7 +160,8 @@ func (c *Client) learn(srcMailbox, destMailbox string, markAsSeen bool, learnFn 
 
 	if markAsSeen {
 		if err := c.clt.MarkSeen(processedMsgUIDs); err != nil {
-			return fmt.Errorf("marking messages as seen failed: %w", err)
+			logger.Warn("marking learned message as seen failed",
+				"error", err)
 		}
 	}
 

--- a/internal/rspamc/rspamc.go
+++ b/internal/rspamc/rspamc.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httputil"
 )
 
 type Client struct {
@@ -45,16 +46,21 @@ func (c *Client) sendRequest(ctx context.Context, url string, hdrs http.Header, 
 		return nil
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		// TODO: check content length, set max. size of body to read
-		buf, err := io.ReadAll(resp.Body)
+	if logger.Enabled(ctx, slog.LevelDebug) {
+		respDump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
-			logger.Error("rspamc reading http error body failed", "error", err)
+			logger.Warn("converting http response to printable representation failed",
+				"error", err,
+			)
 		}
-		logger.Debug("rspamc http response", "body", string(buf), "status", resp.Status)
+		logger.Debug("received http-response", "response", string(respDump))
+	}
+
+	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode >= 200 && resp.StatusCode <= 300 {
 			return nil
 		}
+
 		return fmt.Errorf("request failed with status: %s", resp.Status)
 	}
 

--- a/internal/rspamc/rspamc.go
+++ b/internal/rspamc/rspamc.go
@@ -46,6 +46,11 @@ func (c *Client) sendRequest(ctx context.Context, url string, hdrs http.Header, 
 		return nil
 	}
 
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 512*1024))
+		_ = resp.Body.Close()
+	}()
+
 	if logger.Enabled(ctx, slog.LevelDebug) {
 		respDump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
@@ -53,6 +58,7 @@ func (c *Client) sendRequest(ctx context.Context, url string, hdrs http.Header, 
 				"error", err,
 			)
 		}
+
 		logger.Debug("received http-response", "response", string(respDump))
 	}
 
@@ -75,6 +81,7 @@ func (c *Client) sendRequest(ctx context.Context, url string, hdrs http.Header, 
 		if err != nil {
 			logger.Error("rspamc reading http error body failed", "error", err)
 		}
+
 		if len(buf) != 0 {
 			logger.Debug("response body is not processed", "body", string(buf))
 		}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -60,9 +61,9 @@ func mustParseFlags() *flags {
 	return &result
 }
 
-func configureLogger() *slog.Logger {
+func configureLogger(loglevel slog.Level) *slog.Logger {
 	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level: loglevel,
 		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
 			// do not log timestamp, rspamd-iscan is normally run as
 			// daemon, journald/syslog already adds timestamps
@@ -201,6 +202,21 @@ func monitor(
 	return nil
 }
 
+func toSlogLevel(lvl string) (slog.Level, error) {
+	switch strings.ToLower(lvl) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return 0, fmt.Errorf("unsupported log level: %q", lvl)
+	}
+}
+
 func run() error {
 	flags := mustParseFlags()
 	if flags.printVersion {
@@ -208,12 +224,16 @@ func run() error {
 		return nil
 	}
 
-	logger := configureLogger()
-
 	cfg, err := config.FromFile(flags.cfgPath)
 	if err != nil {
 		return fmt.Errorf("loading config failed: %w", err)
 	}
+
+	loglvl, err := toSlogLevel(cfg.LogLevel)
+	if err != nil {
+		return err
+	}
+	logger := configureLogger(loglvl)
 
 	if flags.credentialsDirectory != "" {
 		if err := cfg.LoadCredentialsFromDirectory(flags.credentialsDirectory); err != nil {


### PR DESCRIPTION
config: make log level configurable

Add a LogLevel field to the config, to allow configuring the minimal
severity of messages to be printed

-------------------------------------------------------------------------------
rspamc: drain and close http response body

To ensure that TCP connections for communicating with rspamd can be
reused, always drain and close the http response body.

-------------------------------------------------------------------------------
rspamc: log rspamd http responses with debug priority

Logging the full http-response can be helpful for debugging and
developing

-------------------------------------------------------------------------------
iscan: don't fail if marking message as seen during learn failed

Marking a message as seen when learning it as spam is not critical.
In the unlikely case that it fails, print a warning and continue instead
of terminating the application.

-------------------------------------------------------------------------------